### PR TITLE
docs: add tutorial on how to add GitHub org to use Read the Doc  and configure `.readthedocs.yaml` within the template folder

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,11 +16,10 @@
 import sys
 import time
 from pathlib import Path
+from importlib.metadata import version
 
 # Attempt to import the version dynamically from GitHub tag.
 try:
-    from importlib.metadata import version
-
     fullversion = version("scikit_package")
 except Exception:
     fullversion = "No version found"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -15,12 +15,13 @@
 
 import sys
 import time
+from importlib.metadata import version
 from pathlib import Path
-from importlib.metadata import version, PackageNotFoundError
 
 try:
+
     fullversion = version("scikit_package")
-except PackageNotFoundError:
+except Exception:
     fullversion = "unknown"
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -84,7 +85,6 @@ copyright = "%Y, The Trustees of Columbia University in the City of New York"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-fullversion = version(project)
 # The short X.Y version.
 version = "".join(fullversion.split(".post")[:1])
 # The full version, including alpha/beta/rc tags.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,7 +22,7 @@ try:
 
     fullversion = version("scikit_package")
 except Exception:
-    fullversion = "unknown"
+    fullversion = "No version found"
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -15,11 +15,11 @@
 
 import sys
 import time
-from importlib.metadata import version
 from pathlib import Path
 
 # Attempt to import the version dynamically from GitHub tag.
 try:
+    from importlib.metadata import version
     fullversion = version("scikit_package")
 except Exception:
     fullversion = "No version found"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -15,8 +15,8 @@
 
 import sys
 import time
-from pathlib import Path
 from importlib.metadata import version
+from pathlib import Path
 
 # Attempt to import the version dynamically from GitHub tag.
 try:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,13 +16,12 @@
 import sys
 import time
 from pathlib import Path
+from importlib.metadata import version, PackageNotFoundError
 
-# Attempt to import the version dynamically from GitHub tag.
 try:
-    from importlib.metadata import version
     fullversion = version("scikit_package")
-except Exception:
-    fullversion = "No version found"
+except PackageNotFoundError:
+    fullversion = "unknown"
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/doc/source/snippets/doc-pr-preview.rst
+++ b/doc/source/snippets/doc-pr-preview.rst
@@ -1,3 +1,17 @@
+#. Visit https://app.readthedocs.org/.
+
+#. Click :guilabel:`Log in using GitHub`.
+
+#. If your repository is under a GitHub organization, follow the extra steps below:
+
+    #. Visit https://github.com/settings/applications
+    
+    #. Click the :guilabel:`Read the Docs Community` application.
+    
+    #. Click the :guilabel:`Request` button for the organization under :guilabel:`Organization Access`, 
+
+    #. Done. Now, Read the Docs can import repositories in the GitHub organization.
+
 #. Visit https://app.readthedocs.org/dashboard/import/.
 
 #. Enter the :guilabel:`Repository name`.
@@ -13,7 +27,6 @@
 #. Enable :guilabel:`Build pull requests for this project`.
 
 #. Click :guilabel:`Update`.
-
 
     .. image:: ../img/doc-pr-preview-setup.png
       :alt: doc-pr-preview-setup

--- a/doc/source/snippets/doc-pr-preview.rst
+++ b/doc/source/snippets/doc-pr-preview.rst
@@ -5,10 +5,10 @@
 #. If your repository is under a GitHub organization, follow the extra steps below:
 
     #. Visit https://github.com/settings/applications
-    
+
     #. Click the :guilabel:`Read the Docs Community` application.
-    
-    #. Click the :guilabel:`Request` button for the organization under :guilabel:`Organization Access`, 
+
+    #. Click the :guilabel:`Request` button for the organization under :guilabel:`Organization Access`,
 
     #. Done. Now, Read the Docs can import repositories in the GitHub organization.
 

--- a/news/doc-preview-org-tutorial.rst
+++ b/news/doc-preview-org-tutorial.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add .readthedocs.yaml under the template folder to allow preview documentation on each PR.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/{{ cookiecutter.github_repo_name }}/.readthedocs.yaml
+++ b/{{ cookiecutter.github_repo_name }}/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "latest"
+
+python:
+  install:
+    - requirements: requirements/docs.txt
+
+sphinx:
+  configuration: doc/source/conf.py

--- a/{{ cookiecutter.github_repo_name }}/doc/source/conf.py
+++ b/{{ cookiecutter.github_repo_name }}/doc/source/conf.py
@@ -75,7 +75,6 @@ copyright = "%Y, {{ cookiecutter.license_holders }}"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-fullversion = version(project)
 # The short X.Y version.
 version = "".join(fullversion.split(".post")[:1])
 # The full version, including alpha/beta/rc tags.

--- a/{{ cookiecutter.github_repo_name }}/doc/source/conf.py
+++ b/{{ cookiecutter.github_repo_name }}/doc/source/conf.py
@@ -15,8 +15,14 @@
 
 import sys
 import time
-from importlib.metadata import version
 from pathlib import Path
+from importlib.metadata import version
+
+# Attempt to import the version dynamically from GitHub tag.
+try:
+    fullversion = version("{{ cookiecutter.package_dir_name }}")
+except Exception:
+    fullversion = "No version found"
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/{{ cookiecutter.github_repo_name }}/doc/source/conf.py
+++ b/{{ cookiecutter.github_repo_name }}/doc/source/conf.py
@@ -15,8 +15,8 @@
 
 import sys
 import time
-from pathlib import Path
 from importlib.metadata import version
+from pathlib import Path
 
 # Attempt to import the version dynamically from GitHub tag.
 try:


### PR DESCRIPTION
Closes https://github.com/Billingegroup/scikit-package/issues/418

<img width="562" alt="Screenshot 2025-05-09 at 8 17 20 AM" src="https://github.com/user-attachments/assets/04f5c43c-e022-4932-bbd9-004c9d831d00" />

Links: 
- Step 1. https://app.readthedocs.org
- Step 3.1 https://github.com/settings/applications
- Steep 4. https://app.readthedocs.org/dashboard/import/
