### PR TITLE
refactor: update URL links from `Billingegroup/repo` to `scikit-package/repo`

### DIFF
--- a/.github/workflows/build-wheel-release-upload.yml
+++ b/.github/workflows/build-wheel-release-upload.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    uses: Billingegroup/release-scripts/.github/workflows/_build-wheel-release-upload.yml@v0
+    uses: scikit-package/release-scripts/.github/workflows/_build-wheel-release-upload.yml@v0
     with:
       project: scikit-package
       maintainer_github_username: sbillinge

--- a/.github/workflows/check-news-item.yml
+++ b/.github/workflows/check-news-item.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   check-news-item:
-    uses: Billingegroup/release-scripts/.github/workflows/_check-news-item.yml@v0
+    uses: scikit-package/release-scripts/.github/workflows/_check-news-item.yml@v0
     with:
       project: scikit-package

--- a/.github/workflows/matrix-and-codecov-on-merge-to-main.yml
+++ b/.github/workflows/matrix-and-codecov-on-merge-to-main.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   matrix-coverage:
-    uses: Billingegroup/release-scripts/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml@v0
+    uses: scikit-package/release-scripts/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml@v0
     with:
       project: scikit-package
       c_extension: false

--- a/.github/workflows/publish-docs-on-release.yml
+++ b/.github/workflows/publish-docs-on-release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   docs:
-    uses: Billingegroup/release-scripts/.github/workflows/_publish-docs-on-release.yml@v0
+    uses: scikit-package/release-scripts/.github/workflows/_publish-docs-on-release.yml@v0
     with:
       project: scikit-package
       c_extension: false

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   tests-on-pr:
-    uses: Billingegroup/release-scripts/.github/workflows/_tests-on-pr.yml@v0
+    uses: scikit-package/release-scripts/.github/workflows/_tests-on-pr.yml@v0
     with:
       project: scikit-package
       c_extension: false

--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,10 @@
 ===============
 
 .. |title| replace:: scikit-package
-.. _title: https://Billingegroup.github.io/scikit-package
+.. _title: https://scikit-package.github.io/scikit-package
 
 .. |Icon| image:: img/logos/scikit-package-logo-text.png
-        :target: https://Billingegroup.github.io/scikit-package
+        :target: https://scikit-package.github.io/scikit-package
         :height: 150px
 
 |PyPi| |Forge| |PythonVersion| |PR|
@@ -15,11 +15,11 @@
 .. |Black| image:: https://img.shields.io/badge/code_style-black-black
         :target: https://github.com/psf/black
 
-.. |CI| image:: https://github.com/Billingegroup/scikit-package/actions/workflows/matrix-and-codecov-on-merge-to-main.yml/badge.svg
-        :target: https://github.com/Billingegroup/scikit-package/actions/workflows/matrix-and-codecov-on-merge-to-main.yml
+.. |CI| image:: https://github.com/scikit-package/scikit-package/actions/workflows/matrix-and-codecov-on-merge-to-main.yml/badge.svg
+        :target: https://github.com/scikit-package/scikit-package/actions/workflows/matrix-and-codecov-on-merge-to-main.yml
 
-.. |Codecov| image:: https://codecov.io/gh/Billingegroup/scikit-package/branch/main/graph/badge.svg
-        :target: https://codecov.io/gh/Billingegroup/scikit-package
+.. |Codecov| image:: https://codecov.io/gh/scikit-package/scikit-package/branch/main/graph/badge.svg
+        :target: https://codecov.io/gh/scikit-package/scikit-package
 
 .. |Forge| image:: https://img.shields.io/conda/vn/conda-forge/scikit-package
         :target: https://anaconda.org/conda-forge/scikit-package
@@ -33,7 +33,7 @@
         :target: https://pypi.org/project/scikit-package/
 
 .. |Tracking| image:: https://img.shields.io/badge/issue_tracking-github-blue
-        :target: https://github.com/Billingegroup/scikit-package/issues
+        :target: https://github.com/scikit-package/scikit-package/issues
 
 ``scikit-package`` offers tools and practices for the scientific community to make better and more reusable Scientific Python packages and applications:
 
@@ -69,16 +69,16 @@ Here is how you can use ``scikit-package`` to create a lightweight Python packag
 Getting started
 ---------------
 
-Are you interested in using ``scikit-package``? Begin with the ``Getting Started`` page in our online documentation at https://Billingegroup.github.io/scikit-package!
+Are you interested in using ``scikit-package``? Begin with the ``Getting Started`` page in our online documentation at https://scikit-package.github.io/scikit-package!
 
 How to cite ``scikit-package``
 ------------------------------
 
 If you use ``scikit-package`` to standardize your Python software, we would like you to cite scikit-package as follows:
 
-   scikit-package, https://github.com/Billingegroup/scikit-package
+   scikit-package, https://github.com/scikit-package/scikit-package
 
 Acknowledgements
 ----------------
 
-This GitHub repository is built and maintained with the help of `scikit-package <https://billingegroup.github.io/scikit-package/>`_ as well.
+This GitHub repository is built and maintained with the help of `scikit-package <https://scikit-package.github.io/scikit-package/>`_ as well.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -148,7 +148,7 @@ html_theme = "sphinx_rtd_theme"
 
 html_context = {
     "display_github": True,  # Integrate GitHub
-    "github_user": "Billingegroup",  # Username
+    "github_user": "scikit-package",  # Username
     "github_repo": "scikit-package",  # Repo name
     "github_version": "main",  # Branch
     "conf_py_path": "/doc/source/",  # Path in repo to the docs folder

--- a/doc/source/examples/migration.rst
+++ b/doc/source/examples/migration.rst
@@ -26,7 +26,7 @@ We understand that your migration journey can be challenging. We offer the follo
 
 #. If you have any questions, first read the :ref:`FAQ <frequently-asked-questions>` for how to customize your package and certain design decisions in the scikit-package template.
 
-#. After you've cross-checked and searched through the FAQ, please feel free to ask questions by creating an issue on the scikit-package repository `here <https://github.com/Billingegroup/scikit-package/issues>`_.
+#. After you've cross-checked and searched through the FAQ, please feel free to ask questions by creating an issue on the scikit-package repository `here <https://github.com/scikig-package/scikit-package/issues>`_.
 
 Migration overview and expected outcome
 ---------------------------------------
@@ -116,7 +116,7 @@ We will setup ``pre-commit`` locally and also via GitHub CI.
 
 #. Type ``git checkout main && git pull upstream main`` and ``git branch -b pre-commit`` to create a new branch called ``pre-commit``.
 
-#. Copy and paste three files of ``.flake8``, ``.isort.cfg``, ``.pre-commit-config.yaml`` from https://github.com/Billingegroup/scikit-package/tree/main/%7B%7B%20cookiecutter.github_repo_name%20%7D%7D to your project directory.
+#. Copy and paste three files of ``.flake8``, ``.isort.cfg``, ``.pre-commit-config.yaml`` from https://github.com/scikig-package/scikit-package/tree/main/%7B%7B%20cookiecutter.github_repo_name%20%7D%7D to your project directory.
 
 #. Type ``git add .flake8 .isort.cfg .pre-commit-config.yaml``
 
@@ -126,7 +126,7 @@ We will setup ``pre-commit`` locally and also via GitHub CI.
 
 #. If you do not want the new changes, you can run ``git restore <file-or-directory-path>`` to revert the changes done by ``pre-commit``.
 
-#. If you want to prevent ``prettier`` from applying on specific files, create ``.`prettierignore`` file at the top project like shown here: https://github.com/Billingegroup/scikit-package/blob/main/.prettierignore
+#. If you want to prevent ``prettier`` from applying on specific files, create ``.`prettierignore`` file at the top project like shown here: https://github.com/scikig-package/scikit-package/blob/main/.prettierignore
 
 #. If you are satisfied with the automatic changes by ``pre-commit run --all-files``, run ``pytest``, type ``git add <file-path(s)>`` and ``git commit -m "style: apply pre-commit hooks with no manual edits"``.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,7 +1,7 @@
 | Software version |release|.
 | Last updated |today|.
 
-Welcome to Billinge Group's ``scikit-package`` documentation!
+Welcome to the ``scikit-package`` official documentation!
 
 ``scikit-package`` offers tools and practices for the scientific community to make better and more reusable Scientific Python packages and applications.
 
@@ -17,7 +17,7 @@ Here are the 3 goals of ``scikit-package`` for the scientific community:
 
 #. We help scientists save time, allowing them to **focus on writing scientific code**.
 
-#. We offer **best practices** from the group's experience in developing scientific software.
+#. We offer **best practices** from the Billinge group's experience in developing scientific software.
 
 Here is an overview of the five levels of reusing and sharing code and the key features of ``scikit-package``:
 
@@ -79,13 +79,13 @@ For technical users, here are some of the advanced features:
 - Generate conda-package ``meta.yaml`` with ``package create conda-forge``.
 - Support headless GitHub CI testing for GUI applications.
 - Support non-pure Python package releases with ``cibuildwheel``.
-- Reusable GitHub Actions workflows located in `Billingegroup/release-scripts <https://github.com/Billingegroup/release-scripts/tree/main/.github/workflows>`_.
+- Reusable GitHub Actions workflows located in `scikit-package/release-scripts <https://github.com/scikit-package/release-scripts/tree/main/.github/workflows>`_.
 
 
 How do I receive support?
 -------------------------
 
-If you have any questions or have trouble, please read the :ref:`Frequently asked questions (FAQ) <frequently-asked-questions>` section to see if your questions have already been answered. If there aren't answers available, please create `GitHub Issues <https://github.com/Billingegroup/scikit-package/issues>`_.
+If you have any questions or have trouble, please read the :ref:`Frequently asked questions (FAQ) <frequently-asked-questions>` section to see if your questions have already been answered. If there aren't answers available, please create `GitHub Issues <https://github.com/scikit-package/scikit-package/issues>`_.
 
 How can I contribute to ``scikit-package``?
 -------------------------------------------
@@ -104,7 +104,7 @@ Authors
 ``scikit-package`` is developed by Billinge Group and its community contributors.
 
 For a detailed list of contributors, see
-https://github.com/Billingegroup/scikit-package/graphs/contributors.
+https://github.com/scikit-package/scikit-package/graphs/contributors.
 
 ================
 Acknowledgements

--- a/doc/source/programming-guides/billinge-group-standards.rst
+++ b/doc/source/programming-guides/billinge-group-standards.rst
@@ -40,7 +40,7 @@ For commit messages and issue titles, we add prefixes adopted from https://www.c
 - Example 1: "feat: create a ``DiffractionObject.morph_to()`` method"
 - Example 2: "bug: handle divide by zero error in ``DiffractionObject.scale_to``"
 
-Please see an example here: https://github.com/Billingegroup/scikit-package/issues. There are a few benefits to adding prefixes to GitHub issue titles. First, it helps us prioritize tasks from the GitHub notifications. Second, it helps reference issues in a comment within an issue or pull request and organize tasks.
+Please see an example here: https://github.com/scikit-package/scikit-package/issues. There are a few benefits to adding prefixes to GitHub issue titles. First, it helps us prioritize tasks from the GitHub notifications. Second, it helps reference issues in a comment within an issue or pull request and organize tasks.
 
 .. attention::
 
@@ -55,11 +55,11 @@ Pull request practices
 
 #. Make PRs small with the possibility of rejection.
 
-#. Write ``closes #<issue-number>`` in the PR comment to automatically close the issue when the PR is merged. See https://github.com/Billingegroup/scikit-package/pull/350.
+#. Write ``closes #<issue-number>`` in the PR comment to automatically close the issue when the PR is merged. See https://github.com/scikit-package/scikit-package/pull/350.
 
 #. A PR should close an issue on GitHub. If there is no issue, make one. If the issue is big, consider breaking it down into smaller issues.
 
-#. Review your own PR. Start as a draft PR, click :guilabel:`Files changed`, add comments, and then request a review. In-line comments are needed if the changes are not obvious for the reviewer. See https://github.com/Billingegroup/scikit-package/pull/310.
+#. Review your own PR. Start as a draft PR, click :guilabel:`Files changed`, add comments, and then request a review. In-line comments are needed if the changes are not obvious for the reviewer. See https://github.com/scikit-package/scikit-package/pull/310.
 
 #. If *another commit* was pushed after “@username ready for review”, write another comment *“@username ready for review after fixing ____”* so that the reviewer is directed to the PR, not the file changes by the new commit.
 
@@ -222,13 +222,13 @@ Naming conventions
 When should we use hyphens ``-`` or underscores ``_`` in file and folder names?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Use hyphens ``-`` for project names, package names, GitHub repositories, folder names, branch names, and static files like ``.rst``, ``.md``, ``.yml``, and ``.png``. For CLI, also use minus signs ``-`` for args  like ``gh pr list --author "@sbillinge"`` Check an example documentation of ``scikit-package`` here: https://github.com/Billingegroup/scikit-package/tree/main/doc/source.
+Use hyphens ``-`` for project names, package names, GitHub repositories, folder names, branch names, and static files like ``.rst``, ``.md``, ``.yml``, and ``.png``. For CLI, also use minus signs ``-`` for args  like ``gh pr list --author "@sbillinge"`` Check an example documentation of ``scikit-package`` here: https://github.com/scikit-package/scikit-package/tree/main/doc/source.
 
 Use underscores ``_`` in the following two cases:
 
 #. Python files, e.g., ``tests/test_diffraction_objects.py``.
 
-#. Project directory names, e.g., ``src/<project_directory_name>``. Modules and packages are imported with spaces replaced by underscores, like ``import bg_mpl_stylesheets``. Here is an example project: https://github.com/Billingegroup/bg-mpl-stylesheets/tree/main/src/bg_mpl_stylesheets.
+#. Project directory names, e.g., ``src/<project_directory_name>``. Modules and packages are imported with spaces replaced by underscores, like ``import bg_mpl_stylesheets``. Here is an example project: https://github.com/scikit-package/bg-mpl-stylesheets/tree/main/src/bg_mpl_stylesheets.
 
 .. note::
 

--- a/doc/source/snippets/news-file-format.rst
+++ b/doc/source/snippets/news-file-format.rst
@@ -5,7 +5,7 @@ We want to write good ``CHANGELOG.rst`` for each release version. These news ite
 
 We can streamline the process of writing ``CHANGELOG.rst`` for each release by compiling the news items from the ``news`` directory.
 
-Here is an example ``CHANGELOG.rst`` https://github.com/Billingegroup/scikit-package/blob/main/CHANGELOG.rst
+Here is an example ``CHANGELOG.rst`` https://github.com/scikit-package/scikit-package/blob/main/CHANGELOG.rst
 
 How do I write good a news item?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/support/frequently-asked-questions.rst
+++ b/doc/source/support/frequently-asked-questions.rst
@@ -127,7 +127,7 @@ In Level 5, why do we adopt ``README.rst`` instead of ``README.md``?
 We adopt ``README.rst`` at Level 5 because reStructuredText (``.rst``) provides a more configurable format and control. One key advantage of ``.rst`` is its native support for advanced formatting, such as precise control over image size and layout: ::
 
   .. |Icon| image:: img/logos/scikit-package-logo-text.png
-      :target: https://Billingegroup.github.io/scikit-package
+      :target: https://scikit-package.github.io/scikit-package
       :height: 150px
 
 Achieving the same result in Markdown often requires raw HTML, which is less readable and may render inconsistently across platforms.
@@ -264,7 +264,7 @@ How do I build API .rst files for a Python package with a namespace import?
 
 If you are using a namespace import, ``sphinx-apidoc`` will not work. We have develoepd our own script called ``auto_api.py`` to generate the API documentation.
 
-#. Run ``git clone https://github.com/Billingegroup/release-scripts.git`` into a folder outside of the project directory. Here is the folder structure:
+#. Run ``git clone https://github.com/scikit-package/release-scripts.git`` into a folder outside of the project directory. Here is the folder structure:
 
     .. code-block:: text
 
@@ -396,7 +396,7 @@ Python |PYTHON_MAX_VERSION| is the current default Python version in ``.github/w
 
    jobs:
     tests-on-pr:
-      uses: Billingegroup/release-scripts/.github/workflows/_tests-on-pr.yml@v0
+      uses: scikit-package/release-scripts/.github/workflows/_tests-on-pr.yml@v0
     with:
       project: package-name
       c_extension: false
@@ -411,7 +411,7 @@ Python |PYTHON_MAX_VERSION| is the current default Python version in ``.github/w
 
    jobs:
     docs:
-      uses: Billingegroup/release-scripts/.github/workflows/_tests-on-pr.yml@v0
+      uses: scikit-package/release-scripts/.github/workflows/_tests-on-pr.yml@v0
     with:
       project: package-name
       c_extension: false
@@ -424,7 +424,7 @@ Python |PYTHON_MAX_VERSION| is the current default Python version in ``.github/w
 
    jobs:
     matrix-coverage:
-      uses: Billingegroup/release-scripts/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml@v0
+      uses: scikit-package/release-scripts/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml@v0
     with:
       ...
       python_versions: "3.11, 3.12"
@@ -445,7 +445,7 @@ In Level 5, I see that another workflow is running once a PR is merged to ``main
 
 The workflow ``.github/workflows/matrix-and-codecov-on-merge-to-main.yml`` is triggered. The goal is to ensure the latest code is tested not only on Linux but also across multiple operating systems and Python versions. This workflow runs tests on macOS (both Apple Silicon and Intel chips), Linux, and Windows and against three different Python versions, including the latest configured version. To modify the Python versions used in the workflows, refer to :ref:`github-actions-python-versions`.
 
-.. note:: These workflow files call scripts located at https://github.com/Billingegroup/release-scripts, which are centrally managed by the ``scikit-package`` development team. This centralized approach ensures that individual packages do not need to be updated separately when adding support for new Python versions or operating systems.
+.. note:: These workflow files call scripts located at https://github.com/scikit-package/release-scripts, which are centrally managed by the ``scikit-package`` development team. This centralized approach ensures that individual packages do not need to be updated separately when adding support for new Python versions or operating systems.
 
 I am encountering a 'build' is requesting 'pull-requests: write' error. How do I fix it?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -714,7 +714,7 @@ In https://github.com/scikit-package/scikit-package:
    * - ``doc/source/conf.py``
      - ``PYTHON_DEFAULT_MAX_VERSION`` and ``PYTHON_DEFAULT_MIN_VERSION``
 
-In https://github.com/Billingegroup/release-scripts:
+In https://github.com/scikit-package/release-scripts:
 
 .. list-table::
    :header-rows: 1

--- a/doc/source/support/frequently-asked-questions.rst
+++ b/doc/source/support/frequently-asked-questions.rst
@@ -563,14 +563,14 @@ Then, you will download the forked repository in your GitHub account to your loc
 
 In the cloned repository on your local machine, you will make edits. You want to first add a description for the changes by "committing" with a message describing the changes. Then you will upload these changes to the ``forked`` repository in your account. This process of updating code from the local computer to the repository hosted by GitHub is called ``pushing``.
 
-From the forked repository, you then want to upload changes to the repository under ``github.com/Billingegroup/scikit-package``, for example. This process is done through a process called ``pull request``. The Project Owner reviews this pull request and merges it into the Billinge group's repository. If you are the contributor as well as the Project Owner, you would be the one who reviews your own code and merges your changes.
+From the forked repository, you then want to upload changes to the repository under ``github.com/scikit-package/scikit-package``, for example. This process is done through a process called ``pull request``. The Project Owner reviews this pull request and merges it into the Billinge group's repository. If you are the contributor as well as the Project Owner, you would be the one who reviews your own code and merges your changes.
 
 I have a general understanding of fork, clone, commit, push, and pull request. How do I set up my repository for packaging?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Please be familiar with the terminology such as "fork", "clone", "push", and "pull request" :ref:`above <github-workflow-overview>`.
 
-You may fork the repository using the "Fork" button on the top right corner of the repository page. This will copy the repository to your GitHub account. e.g., ``github.com/Billingegroup/scikit-package`` to ``github.com/sbillinge/scikit-package``.
+You may fork the repository using the "Fork" button on the top right corner of the repository page. This will copy the repository to your GitHub account. e.g., ``github.com/scikit-package/scikit-package`` to ``github.com/sbillinge/scikit-package``.
 
 Then download the forked repository under your account to the local machine by cloning:
 
@@ -586,7 +586,7 @@ Now, you also want to link with the repository of the organization by adding the
 
 .. note::
 
-   What is ``upstream``? The repository that you forked from, e.g. ``Billingegroup/scikit-package`` is referred to as the ``upstream`` repository.
+   What is ``upstream``? The repository that you forked from, e.g. ``scikit-package/scikit-package`` is referred to as the ``upstream`` repository.
 
 Verify that you have the ``upstream`` URL set up as the organization.
 
@@ -598,18 +598,18 @@ Notice that you also have ``origin`` with an URL linking to your forked reposito
 
 .. note::
 
-  What is ``remote``? The term ``remote`` is the opposite of ``local``. In other words, ``remote`` refers to the repository that is hosted by GitHub. e.g., ``github.com/Billingegroup/scikit-package`` or ``github.com/sbillinge``.
+  What is ``remote``? The term ``remote`` is the opposite of ``local``. In other words, ``remote`` refers to the repository that is hosted by GitHub. e.g., ``github.com/scikit-package/scikit-package`` or ``github.com/sbillinge``.
 
 Do you have a general summary of each term used in the GitHub workflow?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:fork: The process of copying a repository from an organization to your GitHub account. e.g., ``github.com/Billingegroup/scikit-package`` to ``github.com/sbillinge/scikit-package``.
+:fork: The process of copying a repository from an organization to your GitHub account. e.g., ``github.com/scikit-package/scikit-package`` to ``github.com/sbillinge/scikit-package``.
 
-:upstream: The repository of the original source code. e.g., ``github.com/Billingegroup/scikit-package``.
+:upstream: The repository of the original source code. e.g., ``github.com/scikit-package/scikit-package``.
 
 :origin: The forked repository under your account. e.g., ``github.com/sbillinge/scikit-package``.
 
-:remote: The repository that is hosted by GitHub. e.g., ``github.com/Billingegroup/scikit-package`` or ``github.com/sbillinge/scikit-package``.
+:remote: The repository that is hosted by GitHub. e.g., ``github.com/scikit-package/scikit-package`` or ``github.com/sbillinge/scikit-package``.
 
 :branch: The branch serves as a folder that contains the files of the repository. The ``main`` branch is the branch that is used for the final version of the code. Many branches can be created for different features or bug fixes that are later merged into the ``main`` branch.
 
@@ -704,7 +704,7 @@ Which files should be modified when there is a new Python version?
 
 When updating Python version support, please modify the following files accordingly:
 
-In https://github.com/Billingegroup/scikit-package:
+In https://github.com/scikit-package/scikit-package:
 
 .. list-table::
    :header-rows: 1

--- a/doc/source/tutorials/level-5-tutorial.rst
+++ b/doc/source/tutorials/level-5-tutorial.rst
@@ -193,7 +193,7 @@ As you will see in the next section, we'd like to have GitHub Actions write comm
 Add news items in the GitHub pull request
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Before merging to ``main``, we require that each PR includes a file documenting the changes under ``\news``. This ensures that the changes are documented in the ``CHANGELOG.rst`` when you create a new release, as shown in https://billingegroup.github.io/scikit-package/release.html, for example.
+Before merging to ``main``, we require that each PR includes a file documenting the changes under ``\news``. This ensures that the changes are documented in the ``CHANGELOG.rst`` when you create a new release, as shown in https://scikit-package.github.io/scikit-package/release.html, for example.
 
     .. important::
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -132,7 +132,7 @@ def wrapper_setup():
 
 def update_workflow():
     """Generate GitHub workflow .yml files with user input."""
-    CENTRAL_REPO_ORG = "Billingegroup"
+    CENTRAL_REPO_ORG = "scikit-package"
     CENTRAL_REPO_NAME = "release-scripts"
     CENTRAL_WORKFLOW_DIR = ".github/workflows/templates"
     LOCAL_WORKFLOW_DIR = ROOT / ".github" / "workflows"
@@ -144,7 +144,7 @@ def update_workflow():
                       "VERSION": "v0"}
 
     def get_central_workflows():
-        """Get GitHub workflows from Billingegroup/release-scripts."""
+        """Get GitHub workflows from scikit-package/release-scripts."""
         base_url = f"https://api.github.com/repos/{CENTRAL_REPO_ORG}/{CENTRAL_REPO_NAME}/contents/{CENTRAL_WORKFLOW_DIR}"
         response = requests.get(base_url, timeout=5)
         if response.status_code != 200:
@@ -172,7 +172,7 @@ def update_workflow():
 
     def update_local_workflows(central_workflows):
         """Replace existing GitHub workflow files with latest from
-        Billingegroup/release-scripts."""
+        scikit-package/release-scripts."""
         local_workflows = set(f.name for f in LOCAL_WORKFLOW_DIR.glob("*.yml"))
         central_workflow_names = set(central_workflows.keys())
 
@@ -206,16 +206,13 @@ def main():
     Congratulations! A new Python project is created!
     Enter the directory with `cd {{cookiecutter.project_name}}`.
 
-    Are you starting a new project? Build your project and docs next:
-    https://billingegroup.github.io/scikit-package/new-project-guide.html#build-project
-
-    Are you migrating an existing project? Move files to the new directory next:
-    https://billingegroup.github.io/scikit-package/migration-guide.html#move-files
+    Are you starting a new project or Are you migrating an existing project?
+    Visit https://scikit-package.github.io/scikit-package/overview.html for more!
 
     If you have any additional questions, please read our FAQ section or leave issues below:
 
-    FAQ: https://billingegroup.github.io/scikit-package/frequently-asked-questions
-    GitHub issues: https://github.com/Billingegroup/scikit-package/issues
+    FAQ: https://scikit-package.github.io/scikit-package/frequently-asked-questions
+    GitHub issues: https://github.com/scikit-package/scikit-package/issues
     """)
 
     # Dynamically check if the user has selected a non-default Python version
@@ -227,7 +224,7 @@ def main():
         print(
             "ACTION REQUIRED (non-default Python versions): You've entered Python versions outside of the default according to "
             "https://scientific-python.org/specs/spec-0000/. Please consider specifying Python versions following the instructions in the link below:\n"
-            "\nFAQ: https://Billingegroup.github.io/cookiecutter/frequently-asked-questions.html#github-actions\n"
+            "\nFAQ: https://scikit-package.github.io/cookiecutter/frequently-asked-questions.html#github-actions\n"
         )
 
 if __name__ == '__main__':

--- a/news/url-skpkg.rst
+++ b/news/url-skpkg.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Transfer repository from billingegroup org to scikit-package org.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/Billingegroup/scikit-package/"
-Issues = "https://github.com/Billingegroup/scikit-package/issues/"
+Homepage = "https://github.com/scikit-package/scikit-package/"
+Issues = "https://github.com/scikit-package/scikit-package/issues/"
 
 [tool.setuptools-git-versioning]
 enabled = true

--- a/src/scikit_package/__init__.py
+++ b/src/scikit_package/__init__.py
@@ -7,7 +7,7 @@
 # File coded by: Billinge Group members and community contributors.
 #
 # See GitHub contributions for a more detailed list of contributors.
-# https://github.com/Billingegroup/scikit-package/graphs/contributors
+# https://github.com/scikit-package/scikit-package/graphs/contributors
 #
 # See LICENSE.rst for license information.
 #

--- a/src/scikit_package/app.py
+++ b/src/scikit_package/app.py
@@ -1,7 +1,7 @@
 import subprocess
 from argparse import ArgumentParser
 
-SKPKG_GITHUB_URL = "https://github.com/Billingegroup/scikit-package"
+SKPKG_GITHUB_URL = "https://github.com/scikit-package/scikit-package"
 
 
 def create(package_type):

--- a/src/scikit_package/version.py
+++ b/src/scikit_package/version.py
@@ -7,7 +7,7 @@
 # File coded by: Billinge Group members and community contributors.
 #
 # See GitHub contributions for a more detailed list of contributors.
-# https://github.com/Billingegroup/scikit-package/graphs/contributors
+# https://github.com/scikit-package/scikit-package/graphs/contributors
 #
 # See LICENSE.rst for license information.
 #

--- a/{{ cookiecutter.github_repo_name }}/README.rst
+++ b/{{ cookiecutter.github_repo_name }}/README.rst
@@ -124,4 +124,4 @@ For more information on {{ cookiecutter.conda_pypi_package_dist_name }} please v
 Acknowledgements
 ----------------
 
-``{{ cookiecutter.github_repo_name }}`` is built and maintained with `scikit-package <https://billingegroup.github.io/scikit-package/>`_.
+``{{ cookiecutter.github_repo_name }}`` is built and maintained with `scikit-package <https://scikit-package.github.io/scikit-package/>`_.

--- a/{{ cookiecutter.github_repo_name }}/doc/source/index.rst
+++ b/{{ cookiecutter.github_repo_name }}/doc/source/index.rst
@@ -35,7 +35,7 @@ file included with the distribution.
 Acknowledgements
 ================
 
-``{{ cookiecutter.github_repo_name }}`` is built and maintained with `scikit-package <https://billingegroup.github.io/scikit-package/>`_.
+``{{ cookiecutter.github_repo_name }}`` is built and maintained with `scikit-package <https://scikit-package.github.io/scikit-package/>`_.
 
 =================
 Table of contents


### PR DESCRIPTION
### What problem does this PR address?

Closes https://github.com/scikit-package/scikit-package/issues/433

We recently transfer repos from `Billingegroup` to `scikit-package`. So this PR updates URLs in the doc and variables.

### What should the reviewer(s) do?

Please review the new URLs and merge the code. 



- [x] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [x] Documentation (e.g., tutorials, examples, README) has been updated.
    - [x] A tracking issue or plan to update documentation exists.

