### PR TITLE
refactor: indicate correct version will appear in doc PR preview error message

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,7 +22,7 @@ try:
 
     fullversion = version("scikit_package")
 except Exception:
-    fullversion = "No version found"
+    fullversion = "No version found. The correct version will appear in the released version."
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,4 +1,4 @@
-| Software version |release|.
+| Software version |release|
 | Last updated |today|.
 
 Welcome to the ``scikit-package`` official documentation!

--- a/news/tag-pr-preview.rst
+++ b/news/tag-pr-preview.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Indicate the correction software version will be available in documentation built by readthedoc in each PR.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/{{ cookiecutter.github_repo_name }}/doc/source/conf.py
+++ b/{{ cookiecutter.github_repo_name }}/doc/source/conf.py
@@ -22,7 +22,7 @@ from pathlib import Path
 try:
     fullversion = version("{{ cookiecutter.package_dir_name }}")
 except Exception:
-    fullversion = "No version found"
+    fullversion = "No version found. The correct version will appear in the released version."
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/{{ cookiecutter.github_repo_name }}/doc/source/index.rst
+++ b/{{ cookiecutter.github_repo_name }}/doc/source/index.rst
@@ -6,7 +6,7 @@
 
 ``{{ cookiecutter.project_name }}`` - {{ cookiecutter.project_short_description }}
 
-| Software version |release|.
+| Software version |release|
 | Last updated |today|.
 
 ===============


### PR DESCRIPTION
### What problem does this PR address?

Closes https://github.com/scikit-package/scikit-package/issues/440

Instead of giving the following error msg:

<img width="890" alt="Screenshot 2025-05-16 at 11 45 37 AM" src="https://github.com/user-attachments/assets/02b28164-3a36-465b-bc95-7125b61e5c9e" />

The new error msg is `"No version found. The correct version will appear in the released version."


### What should the reviewer(s) do?

Please review the change in the warning msg as recommended and merge. 

- [x] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [x] Documentation (e.g., tutorials, examples, README) has been updated.

