### PR TITLE
docs: provide instructions what to do when release CI fails

### DIFF
--- a/doc/source/release-guides/pypi-github.rst
+++ b/doc/source/release-guides/pypi-github.rst
@@ -54,7 +54,6 @@ Start pre-release
 
    Review the output and remove or suppress unused code when it is not needed to keep the release clean and maintainable.
 
-
 #. Run the following:
 
    .. code-block:: bash
@@ -70,6 +69,10 @@ Start pre-release
 
 #. For ``pre-release``, it will not update the documentation on GitHub Pages. It will also not update the changelog. See the next section for the full release process.
 
+.. note:: 
+
+   Did you encounter any errors in the workflow, such as permission issues? Check the solutions provided in :ref:`faq-release-ci-failed`.
+
 Full release after pre-release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -83,9 +86,11 @@ Full release after pre-release
       $ git tag <version>
       $ git push upstream <version>
 
-#. Notice that the documentation is deployed. It will also update the ``CHANGELOG.rst``.
+#. Notice that ``CHANGELOG.rst`` is also updated with the new release version and the documentation is built under the ``gh-pages`` branch.
 
-#. Now that you have your source code uploaded to ``PyPI``, we will then now provide a conda package as well.
+.. note:: 
+
+   Did you encounter any errors in the workflow, such as issues related to ``CHANGELOG.rst``? Check the solutions provided in :ref:`faq-release-ci-failed`.
 
 What's next? Create conda package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/snippets/codespell-ignore.rst
+++ b/doc/source/snippets/codespell-ignore.rst
@@ -1,4 +1,4 @@
-To ignore a word, add it to ``.codespell/ignore_words.txt``. See an example `here <https://github.com/diffpy/diffpy.fourigui/blob/main/.codespell/ignore_words.txt>`_.
+To ignore a word, add it to ``.codespell/ignore_words.txt``. You can find an example file here: https://github.com/diffpy/diffpy.fourigui/blob/main/.codespell/ignore_words.txt.
 
 To ignore a specific line, add it to ``.codespell/ignore_lines.txt``. See an example below:
 
@@ -8,4 +8,4 @@ To ignore a specific line, add it to ``.codespell/ignore_lines.txt``. See an exa
   ;; The following single-line comment is written in German.
   # Hallo Welt
 
-To ignore a specific file extension, add ``*.ext`` to the ``skip`` section under ``[tool.codespell]`` in ``pyproject.toml``. Please see an example `here <https://github.com/diffpy/diffpy.fourigui/blob/main//pyproject.toml>`_.
+To ignore a specific file extension, add ``*.ext`` to the ``skip`` section under ``[tool.codespell]`` in ``pyproject.toml``. You can find an example file here: https://github.com/diffpy/diffpy.fourigui/blob/main//pyproject.toml.

--- a/doc/source/support/frequently-asked-questions.rst
+++ b/doc/source/support/frequently-asked-questions.rst
@@ -144,6 +144,28 @@ How can I change who is authorized to release a package?
 
 In ``.github/workflows/build-wheel-release-upload.yml``, modify ``maintainer_github_username`` to the desired GitHub username. This username will be able to authorize the release by pushing the tag as instructed in :ref:`release-pypi-github`.
 
+.. _faq-release-ci-failed:
+
+Release CI failed. What should I do?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Pre-release:
+
+- Did you encounter an error under the ``privilege-check`` section in the workflow? Ensure the user performing the release has the GitHub username specified in ``maintainer_github_username`` under ``.github/workflows/build-wheel-release-upload.yml``.
+- Did you encounter an error related to ``PYPI``? Ensure you have ``PAT_TOKEN`` configured at the organization or repository level. Please read :ref:`pypi-token-setup`. Even if ``PYPI_TOKEN`` is already configured, ensure it is the latest token and has not been revoked or expired.
+
+  .. note::
+    
+    As the next step, if you created and pushed ``*.*.*-rc.0``, you may simply bump and create a new version tag of ``*.*.*-rc.1`` and push it to the remote repository.
+
+Release:
+
+- Did you encounter an error related to ``fatal: could not read Username``? Ensure you have ``PAT_TOKEN`` configured at the organization or repository level. Please read :ref:`pat-token-setup`. Even if ``PAT_TOKEN`` is already configured, ensure it is the latest token and has not been revoked or expired.
+- Did you encounter any error from ``Rulesets``? In your repository, visit :menuselection:`Settings -> Rules -> Rulesets`. Then click one or more of the rulesets. For each ruleset, under the :guilabel:`Bypass list`, click :guilabel:`Add bypass` and :guilabel:`Organization admin` to the ruleset. The GitHub workflow will use the ``PAT_TOKEN`` to bypass the ruleset.
+
+  .. note:: 
+    Here, we don't want to bump a new version. As the next step, delete the Git tag in the local by running ``git tag -d <tagname>`` and visit ``https://github.com/<org-or-username>/<package-name>/tags`` to delete it in the remote. Then, follow the same process for a full release by creating a new tag and pushing it to the remote.
+
 How is the package version set and retrieved?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/source/tutorials/level-5-tutorial.rst
+++ b/doc/source/tutorials/level-5-tutorial.rst
@@ -142,7 +142,7 @@ Migration code from Level 4 to Level 5
 
   This will generate a report of unused code in the ``src`` and ``tests`` directories. Below is an example of what these outputs might look like. You can then review the report and decide whether to remove the identified unused code.
 
-    .. code-block:: bash::
+    .. code-block:: bash
 
        #### Example outputs after running vulture ####
        $ vulture src/ tests/

--- a/news/ruleset-config-faq.rst
+++ b/news/ruleset-config-faq.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Provide instructions on how to ensure CHANGELOG.rst can be modified during release by bypassing rulesets if there are any.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/{{ cookiecutter.github_repo_name }}/CODE_OF_CONDUCT.rst
+++ b/{{ cookiecutter.github_repo_name }}/CODE_OF_CONDUCT.rst
@@ -67,7 +67,7 @@ Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-sb2896@columbia.edu. All complaints will be reviewed and investigated promptly and fairly.
+{{ cookiecutter.maintainer_email }}. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.


### PR DESCRIPTION
### What problem does this PR address?

Closes https://github.com/scikit-package/scikit-package/issues/443

This PR address the questions of "what happens when release CI fail" after creating and pushing the tag to the remote.

### What should the reviewer(s) do?

Please read the content. Please also check my in-line comments. 

- [x] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [x] Documentation (e.g., tutorials, examples, README) has been updated.
