### PR TITLE
docs: provide an instruction when not to follow the file/folder naming convention for configuration files.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
         :target: https://scikit-package.github.io/scikit-package
         :height: 150px
 
-|PyPi| |Forge| |PythonVersion| |PR|
+|PyPI| |Forge| |PythonVersion| |PR|
 
 |CI| |Codecov| |Black| |Tracking|
 
@@ -26,7 +26,7 @@
 
 .. |PR| image:: https://img.shields.io/badge/PR-Welcome-29ab47ff
 
-.. |PyPi| image:: https://img.shields.io/pypi/v/scikit-package
+.. |PyPI| image:: https://img.shields.io/pypi/v/scikit-package
         :target: https://pypi.org/project/scikit-package/
 
 .. |PythonVersion| image:: https://img.shields.io/pypi/pyversions/scikit-package

--- a/doc/source/programming-guides/billinge-group-standards.rst
+++ b/doc/source/programming-guides/billinge-group-standards.rst
@@ -222,7 +222,7 @@ Naming conventions
 When should we use hyphens ``-`` or underscores ``_`` in file and folder names?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Use hyphens ``-`` for project names, package names, GitHub repositories, folder names, branch names, and static files like ``.rst``, ``.md``, ``.yml``, and ``.png``. For CLI, also use minus signs ``-`` for args  like ``gh pr list --author "@sbillinge"`` Check an example documentation of ``scikit-package`` here: https://github.com/scikit-package/scikit-package/tree/main/doc/source.
+Use hyphens ``-`` for project names, package names, GitHub repositories, folder names, branch names, and static files like ``.rst``, ``.md``, ``.yml``, and ``.png``. For CLI, also use hyphens ``-`` for args like ``gh pr list --author "@sbillinge"`` Check an example documentation of ``scikit-package`` here: https://github.com/scikit-package/scikit-package/tree/main/doc/source.
 
 Use underscores ``_`` in the following two cases:
 
@@ -232,9 +232,11 @@ Use underscores ``_`` in the following two cases:
 
 .. note::
 
-  ``scikit-package`` automatically creates a folder with underscores ``_`` for the project directory name and ``.py`` files.
+  ``scikit-package`` automatically creates a folder with underscores ``_`` for the project directory name and ``.py`` files. We recommend using a single word for folder names that contain Python scripts, e.g., ``src/example_package/parsers``, so that it can be imported as ``from example_package.parsers import <module>``. This follows Python conventions.
 
-  We recommend using a single word for folder names that contain Python scripts, e.g., ``src/example_package/parsers``, so that it can be imported as ``from example_package.parsers import <module>``. This follows Python conventions.
+.. warning:: 
+    
+    There are still cases where we do not strictly follow the above conventions, typically for configuration files. In such cases, we adhere to the naming conventions of the respective tool. For example, ``.codespell/ignore_lines.txt`` is a configuration file for the ``codespell`` tool. ``.github/ISSUE_TEMPLATE`` is the designated folder for storing GitHub issue templates. If you are unsure, please feel free to open an issue in the ``scikit-package`` GitHub repository.
 
 Error message
 -------------

--- a/news/naming-convention.rst
+++ b/news/naming-convention.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Provide an instruction when not to follow the file/folder naming convention for configuration files.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/{{ cookiecutter.github_repo_name }}/README.rst
+++ b/{{ cookiecutter.github_repo_name }}/README.rst
@@ -8,7 +8,7 @@
         :target: https://{{ cookiecutter.github_username_or_orgname }}.github.io/{{ cookiecutter.github_repo_name }}
         :height: 100px
 
-|PyPi| |Forge| |PythonVersion| |PR|
+|PyPI| |Forge| |PythonVersion| |PR|
 
 |CI| |Codecov| |Black| |Tracking|
 
@@ -26,7 +26,7 @@
 
 .. |PR| image:: https://img.shields.io/badge/PR-Welcome-29ab47ff
 
-.. |PyPi| image:: https://img.shields.io/pypi/v/{{ cookiecutter.conda_pypi_package_dist_name }}
+.. |PyPI| image:: https://img.shields.io/pypi/v/{{ cookiecutter.conda_pypi_package_dist_name }}
         :target: https://pypi.org/project/{{ cookiecutter.conda_pypi_package_dist_name }}/
 
 .. |PythonVersion| image:: https://img.shields.io/pypi/pyversions/{{ cookiecutter.conda_pypi_package_dist_name }}


### PR DESCRIPTION
### What problem does this PR address?

Closes https://github.com/scikit-package/scikit-package/issues/444

This PR is used to indicate when not to apply the `-` or `_` naming convention:

### What should the reviewer(s) do?

Please provide feedback on the instruction if it needs to be modified.

- [x] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [x] Documentation (e.g., tutorials, examples, README) has been updated.

