### PR TITLE
feat: Allow users to set default configurations.

### DIFF
--- a/news/config.rst
+++ b/news/config.rst
@@ -1,6 +1,7 @@
 **Added:**
 
-* no news added: correct level 3 tutorial on the term module and package
+* allow user to set default configs from `.skpkgrc`.
+* allow user to change configs path by system variable `SKPKG_CONFIG_FILE`
 
 **Changed:**
 

--- a/src/scikit_package/app.py
+++ b/src/scikit_package/app.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from argparse import ArgumentParser
+from pathlib import Path
 
 SKPKG_GITHUB_URL = "https://github.com/scikit-package/scikit-package"
 SKPKG_CONFIG_FILE = "~/.skpkgrc"
@@ -8,8 +9,9 @@ try:
     config_file = os.environ["SKPKG_CONFIG_FILE"]
 except KeyError:
     config_file = SKPKG_CONFIG_FILE
-config_file = os.path.expanduser(os.path.expandvars(config_file))
-exist_config = os.path.exists(config_file)
+config_file = os.path.expandvars(config_file)
+config_file = Path(config_file).expanduser()
+exist_config = config_file.exists()
 
 
 def create(package_type):

--- a/src/scikit_package/app.py
+++ b/src/scikit_package/app.py
@@ -31,21 +31,21 @@ def update():
 
 def run_cookiecutter(repo_url):
     try:
-        if not exist_config:
+        if exist_config:
             subprocess.run(
-                [
-                    "cookiecutter",
-                    repo_url,
-                ],
-                check=True,
-            )
-        else:
-            subprocess.run(  # if config file exists
                 [
                     "cookiecutter",
                     repo_url,
                     "--config-file",
                     config_file,
+                ],
+                check=True,
+            )
+        else:
+            subprocess.run(
+                [
+                    "cookiecutter",
+                    repo_url,
                 ],
                 check=True,
             )

--- a/src/scikit_package/app.py
+++ b/src/scikit_package/app.py
@@ -1,7 +1,15 @@
+import os
 import subprocess
 from argparse import ArgumentParser
 
 SKPKG_GITHUB_URL = "https://github.com/scikit-package/scikit-package"
+SKPKG_CONFIG_FILE = "~/.skpkgrc"
+try:
+    config_file = os.environ["SKPKG_CONFIG_FILE"]
+except KeyError:
+    config_file = SKPKG_CONFIG_FILE
+config_file = os.path.expanduser(os.path.expandvars(config_file))
+exist_config = os.path.exists(config_file)
 
 
 def create(package_type):
@@ -23,13 +31,25 @@ def update():
 
 def run_cookiecutter(repo_url):
     try:
-        subprocess.run(
-            [
-                "cookiecutter",
-                repo_url,
-            ],
-            check=True,
-        )
+        if not exist_config:
+            subprocess.run(
+                [
+                    "cookiecutter",
+                    repo_url,
+                ],
+                check=True,
+            )
+        else:
+            subprocess.run(  # if config file exists
+                [
+                    "cookiecutter",
+                    repo_url,
+                    "--config-file",
+                    config_file,
+                ],
+                check=True,
+            )
+
     except subprocess.CalledProcessError as e:
         print(f"Failed to run scikit-package for the following reason: {e}")
 


### PR DESCRIPTION
### What problem does this PR address?
Closes #375 


### What should the reviewer(s) do?
Use the following checklist items when applicable (select only what applies):
- [x] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [x] A tracking issue or plan to update documentation exists.


### implementation

`cookiecutter`  provides a way to set the default configs through "-- config-file" option in  https://cookiecutter.readthedocs.io/en/latest/advanced/user_config.html.This. This implementation utilized this option. 

### expected usage

(1) Ethan wants better default values. He create `~/.skpgrc`
```yaml
{
    "default_context":
  {
    "project_name": a-new-project-package",
    "github_username_or_orgname": "billingegroup",
    "github_repo_name": "{{ cookiecutter.project_name|replace(' ', '-')|lower }}",
    "conda_pypi_package_dist_name": "{{ cookiecutter.project_name|replace(' ', '-')|lower }}",
    "package_dir_name": "{{ cookiecutter.project_name|replace(' ', '_')|replace('-', '_')|lower }}",
    "contributors": "Sangjoon Lee, Simon Billinge",
    "_copy_without_render": ["*.html", "*.js", ".github/*"]
  }
}
```

(2) Ethan wants to store the configs in `~/configs/.skpkgrc` instead of `~/.skpkgrc`; he adds the following to his terminal profiles.
``` shell
export SKPKGR_CONFIG_FILE="$HOME/configs/.skpkgrc"
```
and move `~/.skpkgrc` to `~/configs/.skpkgrc`

After either (1) or (2), the prompts for `package create system` will become
Now the prompts become
![image](https://github.com/user-attachments/assets/1f80685f-94ce-4ffd-8d34-79f026b7fb2d)

(3) Ethan likes `skpkg` and wants to set all the default values from `skpkgrc`. He did nothing about the configs, and nothing new happened.