### PR TITLE
refactor: instruct user to download auto-api generation package from `conda-forge` instead of `PyPI`

### DIFF
--- a/doc/source/support/frequently-asked-questions.rst
+++ b/doc/source/support/frequently-asked-questions.rst
@@ -224,7 +224,7 @@ You can generate ``.rst`` files using the ``sphinx-apidoc`` extension.
 
     .. code-block:: bash
 
-        pip install sphinx-apidoc
+        pip install sphinxcontrib-apidoc
 
 #. Run the following command to generate ``.rst`` under the ``doc/source/api`` directory:
 

--- a/doc/source/support/frequently-asked-questions.rst
+++ b/doc/source/support/frequently-asked-questions.rst
@@ -218,25 +218,25 @@ How can I preview the documentation in real-time?
 How do I build API .rst files automatically for a standard Python package?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can generate ``.rst`` files using the ``sphinx-apidoc`` extension.
+Here is how you can **automate** the process of generating API documentation for a standard Python package located in the ``doc/source/api`` folder.
 
-#. Install ``sphinx-apidoc``:
+.. note::
 
-    .. code-block:: bash
+  Your package is considered a **standard package** if it is imported as ``import <package_name>`` instead of ``import <namespace_name>.<package_name>``.
 
-        pip install sphinxcontrib-apidoc
+#. Add ``sphinxcontrib-apidoc`` to the ``requirements/docs.txt`` file.
 
-#. Run the following command to generate ``.rst`` under the ``doc/source/api`` directory:
+    .. code-block:: text
 
-    .. code-block:: bash
+      sphinx
+      sphinx_rtd_theme
+      sphinx-copybutton
+      sphinxcontrib-apidoc
+      ...
 
-        sphinx-apidoc -o doc/source/api src/<package_dir_name>
+#. Run ``conda install --file requirements/docs.txt`` to install the new dependency.
 
-#. Done!
-
-Instead of manually running the ``sphinx-apidoc -o ..`` command from your terminal, here is a recommended way to **automate** the process of generating API documentation:
-
-#. Replace the following code block in your ``doc/source/conf.py`` from
+#. Replace the following code block in your ``doc/source/conf.py`` file from
 
     .. code-block:: python
 
@@ -247,6 +247,7 @@ Instead of manually running the ``sphinx-apidoc -o ..`` command from your termin
             "sphinx.ext.viewcode",
             "sphinx.ext.intersphinx",
             "sphinx_rtd_theme",
+            "sphinx_copybutton",
             "m2r",
         ]
 
@@ -261,6 +262,7 @@ Instead of manually running the ``sphinx-apidoc -o ..`` command from your termin
             "sphinx.ext.viewcode",
             "sphinx.ext.intersphinx",
             "sphinx_rtd_theme",
+            "sphinx_copybutton",
             "m2r",
         ]
 
@@ -271,13 +273,25 @@ Instead of manually running the ``sphinx-apidoc -o ..`` command from your termin
         apidoc_excluded_paths = ['tests']
         apidoc_separate_modules = True
 
-#. Replace ``<package_dir_name>`` with the directory name under ``src``, e.g., ``my_package``.
+#. Next to the ``apidoc_module_dir`` variable above, replace ``<package_dir_name>`` with the directory name under ``src``, e.g., ``my_package``.
 
-#. Run ``sphinx-reload doc``.
+#. Run ``sphinx-reload doc`` to build and host the documentation.
 
-#. Notice that the ``.rst`` files under ``doc/source/api`` are generated whenever the documentation is re-rendered.
+    Notice that the ``.rst`` files under ``doc/source/api`` are generated whenever the documentation is re-rendered.
 
-#. Done! You can ``git add doc/source/api`` and commit the changes.
+#. Add the following block to your ``doc/source/index.rst`` file:
+
+    .. code-block:: text
+
+      .. toctree::
+         :maxdepth: 2
+         :caption: API Reference
+
+          Package API <api/package_dir_name>
+
+#. Now, you should see the :guilabel:`API Package` section in the left menu bar of the documentation. Click on it to see the API documentation.
+
+#. Done! If you have any issues, please feel free to open an issue in the ``scikit-package`` GitHub repository.
 
 .. _faq-doc-api-namespace:
 

--- a/news/level-3-init.rst
+++ b/news/level-3-init.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* no news added: correct level 3 tutorial on the term module and package
+* no news added: correct level 3 tutorial on the term module and package 
 
 **Changed:**
 

--- a/news/sphinx-api-fix.rst
+++ b/news/sphinx-api-fix.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* Instruct user to install API .rst file generation pacakge from conda instead of pip.
+* Instruct user to install API .rst file generation pacakge from conda-forge instead of PyPI.
 
 **Deprecated:**
 

--- a/news/sphinx-api-fix.rst
+++ b/news/sphinx-api-fix.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* no news added: correct level 3 tutorial on the term module and package
+* no news added: modify the library name for api generation. 
 
 **Changed:**
 

--- a/news/sphinx-api-fix.rst
+++ b/news/sphinx-api-fix.rst
@@ -1,10 +1,10 @@
 **Added:**
 
-* no news added: modify the library name for api generation. 
+* <news item>
 
 **Changed:**
 
-* <news item>
+* Instruct user to install API .rst file generation pacakge from conda instead of pip.
 
 **Deprecated:**
 


### PR DESCRIPTION
### Problem

We want users to use `conda-forge` as much as we can. Hence this PR suggests installing the auto api generation package from `conda-forge` instead of `PyPI`. 

### What should reviewer(s) do?

Please feel free to check the rendered doc section to see the new change!

<img width="645" alt="Screenshot 2025-05-20 at 10 24 22 PM" src="https://github.com/user-attachments/assets/72621ab8-1fc1-4c07-b504-7dec7debffdb" />

<img width="626" alt="Screenshot 2025-05-20 at 10 24 34 PM" src="https://github.com/user-attachments/assets/f7920716-b397-46a4-8a6f-56b9099fc55b" />

<img width="623" alt="Screenshot 2025-05-20 at 10 24 41 PM" src="https://github.com/user-attachments/assets/2336e127-72ef-4361-8cc2-8f711f7c7f04" />

- [x] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [x] Documentation (e.g., tutorials, examples, README) has been updated.

