### PR TITLE
docs: Add note to keep functions as modular as possible

### DIFF
--- a/doc/source/tutorials/level-1-2-3-tutorials.rst
+++ b/doc/source/tutorials/level-1-2-3-tutorials.rst
@@ -95,7 +95,7 @@ Here is the full content of the ``example_code.py`` file:
     print(dot_product(v3, v4))  # returns 83
 
 .. note::
-     When writing a function in Python, it is best practice to keep its functionality as modular as possible. This means that the function should do one thing and do it well. This makes it easier to read, understand, and maintain the code.
+     When writing a function, it is best practice to keep its functionality as modular as possible. This means that the function should do one thing and do it well. This makes it easier to read, understand, and maintain the code.
 
 Congratulation! You are now able to reuse code within a file by creating a function. Before we move on to the next level, let's learn about setting up a ``conda`` environment to install packages and run Python code in the following section.
 

--- a/doc/source/tutorials/level-1-2-3-tutorials.rst
+++ b/doc/source/tutorials/level-1-2-3-tutorials.rst
@@ -94,6 +94,9 @@ Here is the full content of the ``example_code.py`` file:
     v4 = [7, 8]
     print(dot_product(v3, v4))  # returns 83
 
+.. note::
+     When writing a function in Python, it is best practice to keep its functionality as modular as possible. This means that the function should do one thing and do it well. This makes it easier to read, understand, and maintain the code.
+
 Congratulation! You are now able to reuse code within a file by creating a function. Before we move on to the next level, let's learn about setting up a ``conda`` environment to install packages and run Python code in the following section.
 
 .. _conda-env-setup-simple:

--- a/news/modular-functions.rst
+++ b/news/modular-functions.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add note to instruct users to keep functions as modular as possible
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
closes #463 

The note of keeping functions modular was in the overleaf, now it is here in the form of a note. 

<img width="901" alt="Screenshot 2025-05-22 at 4 41 56 PM" src="https://github.com/user-attachments/assets/4cc606fa-f793-48e7-ba3c-da3104e71aee" />
