### PR TITLE
chore: add `_build` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 .Python
 env/
 build/
+_build/
 develop-eggs/
 dist/
 downloads/

--- a/news/build-ignore.rst
+++ b/news/build-ignore.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* ignore ``_build`` in `.gitignore`.
+* Add ``_build`` to ``.gitignore`` to prevent accidental commit of docs when using ``sphinx-reload``.
 
 **Changed:**
 

--- a/news/build-ignore.rst
+++ b/news/build-ignore.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* ignore ``_build`` in `.gitignore`.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/{{ cookiecutter.github_repo_name }}/.gitignore
+++ b/{{ cookiecutter.github_repo_name }}/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 .Python
 env/
 build/
+_build/
 develop-eggs/
 dist/
 downloads/


### PR DESCRIPTION
when using `sphinx-reload` to dynamically edit docs, it generates the directory `_build`. Adding this to the gitignore makes sure we dont accidentally commit these docs