### PR TITLE
docs: add description of public vs private functions to level 2

### DIFF
--- a/doc/source/tutorials/level-1-2-3-tutorials.rst
+++ b/doc/source/tutorials/level-1-2-3-tutorials.rst
@@ -177,6 +177,31 @@ This is the content of ``file_two.py``:
 
     Notice that in ``file_two.py``, you can import the entire module ``shared_functions`` and use the function ``dot_product`` by prefixing it with the module name. Importing a modele is a good practice when you have multiple functions in the same file. This way, you can avoid name conflicts and make your code more readable.
 
+Private vs. Public functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+When reusing functions across modules, it’s helpful to distinguish between **public** and **private** functions. In Python, a function name starting with an underscore (e.g., ``_helper_function()``) is considered private—meant for internal use within the module. This signals to other developers and tools that it’s not part of the public API.
+
+Functions **without** a leading underscore are public and safe to use elsewhere in your project. Public functions are usually well-documented and tested, while private ones are simpler helpers used internally. As a rule of thumb, if a function is reused across modules, it should likely be public.
+
+For example, the following code calculates the distance between two points. The private function ``_calculate_distance()`` does the math, and the public function ``distance_between_points()`` validates inputs and calls it:
+
+.. code-block:: python
+
+    import numpy as np
+
+     # Private function: does the math to compute distance
+     def _calculate_distance(x1, y1, x2, y2):
+          """Compute the Euclidean distance between two 2D points."""
+          return np.sqrt(((x2 - x1)**2 + (y2 - y1)**2))
+
+     # Public function: checks that inputs look okay and calls the private function
+     def distance_between_points(p1, p2):
+          """Calculate distance between two 2D points given as (x, y) pairs."""
+          if len(p1) != 2 or len(p2) != 2:
+               print("Error: Each point must have exactly two values (x and y).")
+               return None
+          return _calculate_distance(p1[0], p1[1], p2[0], p2[1])
+
 Are you having trouble running the code?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/news/private-vs-public.rst
+++ b/news/private-vs-public.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Describe the difference between public and private functions in level 2 of the documentation.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
closes #462 

Instead of having a description of private vs public functions in the paper, this has been moved to level 2 of the docs with a simple example.