### PR TITLE
ci: allow setting global `CODECOV_TOKEN` at the org level instead of manually setting different one for each repo 

### DIFF
--- a/doc/source/snippets/github-codecov-setup.rst
+++ b/doc/source/snippets/github-codecov-setup.rst
@@ -1,30 +1,38 @@
 .. _codecov-token-setup:
 
-We also want to ensure we report that tests are written for the incoming code and report in the incoming PR as shown below:
+We also want to ensure that tests are written for incoming code and that reports appear in the incoming PR, as shown below.
 
 .. image:: ../img/codecov-pr.png
-   :alt: codecov-in-pr-comment
+    :alt: codecov-in-pr-comment
+
+.. warning::
+
+    **Is this NOT your first time setting up Codecov?** Setting up the Codecov report can be done just once for all projects under your account or a GitHub organization with the "global token." Please check whether you already have a Codecov token. If it exists, you may still follow the steps, but you don't have to create a new token. Instead, you can use the existing token.
 
 #. Ensure your GitHub repository is public.
 
-#. Visit https://app.codecov.io/
+#. Visit ``https://app.codecov.io/account/gh/<your_github_username_or_orgname>/org-upload-token``, replacing ``<your_github_username_or_orgname>`` with your actual GitHub username or organization name.
 
-#. Click :guilabel:`Configure Codecov's GitHub app`.
+#. Under :guilabel:`Select an authentication option`, select ``Required``.
 
-#. Scroll down, find the repository, and click :guilabel:`Configure`.
+#. Click :guilabel:`Generate` or :guilabel:`Regenerate` to create a new token.
 
-#. Scroll down again, copy ``CODECOV_TOKEN``, shown below:
+#. Click on the clipboard symbol to copy ``CODECOV_TOKEN``. Copy the one that starts with ``CODECOV_TOKEN=``. Here is an example of what it looks like:
 
-    .. image:: ../img/codecov-token.png
-        :alt: codecov-list-github-projects
+    .. code-block:: text
 
-#. In your GitHub repository, visit :menuselection:`Settings -> Actions -> Secrets and Variables`.
+        CODECOV_TOKEN=abcd1234-5678-1234-5678-b862619523bd
 
-#. Click :guilabel:`New repository secret`.
+#. In your GitHub repository, visit :menuselection:`Settings --> Actions --> Secrets and Variables`.
 
-#. Paste the token value in the previous step and name it as ``CODECOV_TOKEN`` as shown below:
+#. If the repository is under your personal account, click :guilabel:`New repository secret`.
 
-    .. image:: ../img/codecov-github.png
-        :alt: codecov-list-github-projects
+#. If the repository is under an organization, click :menuselection:`Manage organization secrets --> New organization secret`.
 
-#. Done. From now on, a new comment will be generated on each PR.
+#. Under the :guilabel:`Name` field, type ``CODECOV_TOKEN``.
+
+#. Under the :guilabel:`Secret` field, paste the ``CODECOV_TOKEN`` value you copied earlier without any modification.
+
+#. Click :guilabel:`Add secret` to save the token.
+
+#. Done. From now on, a new Codecov comment will be generated on each PR!

--- a/doc/source/snippets/github-codecov-setup.rst
+++ b/doc/source/snippets/github-codecov-setup.rst
@@ -1,6 +1,6 @@
 .. _codecov-token-setup:
 
-We also want to ensure that tests are written for incoming code and that reports appear in the incoming PR, as shown below.
+We also want to ensure we report that tests are written for the incoming code and report in the incoming PR as shown below:
 
 .. image:: ../img/codecov-pr.png
     :alt: codecov-in-pr-comment

--- a/doc/source/support/frequently-asked-questions.rst
+++ b/doc/source/support/frequently-asked-questions.rst
@@ -223,7 +223,7 @@ Pre-release:
 Release:
 
 - Did you encounter an error related to ``fatal: could not read Username``? Ensure you have ``PAT_TOKEN`` configured at the organization or repository level. Please read :ref:`pat-token-setup`. Even if ``PAT_TOKEN`` is already configured, ensure it is the latest token and has not been revoked or expired.
-- Did you encounter any error from ``Rulesets``? In your repository, visit :menuselection:`Settings -> Rules -> Rulesets`. Then click one or more of the rulesets. For each ruleset, under the :guilabel:`Bypass list`, click :guilabel:`Add bypass` and :guilabel:`Organization admin` to the ruleset. The GitHub workflow will use the ``PAT_TOKEN`` to bypass the ruleset.
+- Did you encounter any error from ``Rulesets``? In your repository, visit :menuselection:`Settings --> Rules --> Rulesets`. Then click one or more of the rulesets. For each ruleset, under the :guilabel:`Bypass list`, click :guilabel:`Add bypass` and :guilabel:`Organization admin` to the ruleset. The GitHub workflow will use the ``PAT_TOKEN`` to bypass the ruleset.
 
   .. note::
     Here, we don't want to bump a new version. As the next step, delete the Git tag in the local by running ``git tag -d <tagname>`` and visit ``https://github.com/<org-or-username>/<package-name>/tags`` to delete it in the remote. Then, follow the same process for a full release by creating a new tag and pushing it to the remote.

--- a/doc/source/tutorials/tutorial-level-5-migration.rst
+++ b/doc/source/tutorials/tutorial-level-5-migration.rst
@@ -170,7 +170,7 @@ Apply pre-commit auto-fixes without manual edits
 
     .. note::
 
-        The new ``upstream/migration`` branch can be created by the project maintainer or owner. On the main page of the upstream repository, click :menuselection:`main -> Switch branches/tags -> Find or create a branch` and type ``migration``. This will create a new branch called ``migration``.
+        The new ``upstream/migration`` branch can be created by the project maintainer or owner. On the main page of the upstream repository, click :menuselection:`main --> Switch branches/tags --> Find or create a branch` and type ``migration``. This will create a new branch called ``migration``.
 
 #. Wait for the PR to be merged to ``upstream/migration`` branch.
 

--- a/doc/source/tutorials/tutorial-level-5.rst
+++ b/doc/source/tutorials/tutorial-level-5.rst
@@ -67,7 +67,7 @@ Upload ``README.md`` to your GitHub repository
 Step 2. Automate code linting and testing with GitHub Actions
 -------------------------------------------------------------
 
-We will do 3 things in order to automate testing, linting, infrastructure in your GitHub repository.
+We will do 3 things in order to automate testing, linting, infrastructure in your GitHub repository. Rest assured that these configuration steps are only done once!
 
 - :ref:`tutorial-5-pre-commit-ci`
 - :ref:`tutorial-5-github-codecov-setup`

--- a/news/codecov-org.rst
+++ b/news/codecov-org.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* no news added - refine doc to support global codecov token.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address?

Closes #490 

Finally, we are able to set all our CIs  (`PYPI_TOKEN`, `PAT_TOKEN`, and `CODECOV_TOKEN` `PRE_COMMIT CI`) all at the org level. 

Here is a quick test CI using my `bobleesj-test-org` repo: https://github.com/bobleesj-test-org/bobleesj.release/pull/30

<img width="742" alt="Screenshot 2025-05-29 at 11 13 38 AM" src="https://github.com/user-attachments/assets/54e7f8be-07a7-453d-8e1f-f15d39d50a28" />

Org secret:

<img width="1196" alt="Screenshot 2025-05-29 at 11 18 11 AM" src="https://github.com/user-attachments/assets/b0c3b8b8-f5a9-41f4-8f73-d93ca35a42f0" />



### What should the reviewer(s) do?

Please review the new instruction I've provided with a screenshot:

- [x] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [x] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
