### PR TITLE
docs Provide a better -h description for package add news -h.

### DIFF
--- a/news/news-parser-help.rst
+++ b/news/news-parser-help.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Provide a better -h description for package add news -h.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/scikit_package/app.py
+++ b/src/scikit_package/app.py
@@ -1,4 +1,5 @@
 from argparse import ArgumentParser
+import argparse
 
 from scikit_package.cli import add, create
 
@@ -41,7 +42,20 @@ def setup_subparsers(parser):
     _add_subcommands(subparsers_create, create_commands, create.package)
     # "add" subparser
     parser_add = parser.add_parser(
-        "add", help="Add a new file like a news item"
+        "add",
+        help="Create a news file for the branch and add a news item to it.",
+        description=(
+            "This command streamlines the process of writing news items.\n\n"
+            "Add -a, -c, -d, -r, -f, or -s to specify the news type.\n"
+            "Then, use -m <message> to write te news message.\n"
+            "Type `package add news -h` to see what each flag means.\n\n"
+            "Examples:\n"
+            "  package add news --add -m \"Add black pre-commit hook.\"\n"
+            "  package add news -a -m \"Support dark mode in UI.\"\n"
+            "  package add news -f -m \"Correct logic error in settings parser.\"\n"
+            "  package add no-news -m \"Fix minor typo.\""
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     subparsers_add = parser_add.add_subparsers(
         dest="subcommand", required=True


### PR DESCRIPTION
### What problem does this PR address?

Closes https://github.com/scikit-package/scikit-package/issues/523

Result:

```
package add news -h
```

and

```
usage: package add news [-h] -m MESSAGE [-a] [-c] [-d] [-r] [-f] [-s] [-n]

This command streamlines the process of writing news items.

Add -a, -c, -d, -r, -f, or -s to specify the news type.
If no news is necessary, add -n instead of any of the above.
Then, add `-m <message>` to write the news message.

Examples:
  package add news --add -m "Support dark mode in UI."
  package add news -a -m "Support dark mode in UI."
  package add news --no-news -m "Fix minor typo."
  package add news -n -m "Fix minor typo."

options:
  -h, --help            show this help message and exit
  -m, --message MESSAGE
                        News content.
  -a, --add             Added
  -c, --change          Changed
  -d, --deprecate       Deprecated
  -r, --remove          Removed
  -f, --fix             Fixed
  -s, --security        Security
  -n, --no-news         Inform a brief reason why no news item is needed.
```

### What should the reviewer(s) do?

Please review and merge!

- [x] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [x] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).