### PR TITLE
docs: optimize and simplify migration docs and fix typos

### DIFF
--- a/doc/source/tutorials/tutorial-level-5-migration.rst
+++ b/doc/source/tutorials/tutorial-level-5-migration.rst
@@ -322,8 +322,8 @@ Move essential files to run local tests
 
         $ git status
 
-.. attention::
-    If you see any files under ``src`` or ``tests`` that are modified, **manually check these files** and decide whether you want to keep the changes made by ``scikit-package`` or not.
+    .. attention::
+        If you see any files under ``src`` or ``tests`` that are modified, **manually check these files** and decide whether you want to keep the changes made by ``scikit-package`` or not.
 
 #. By default, ``scikit-package`` generates an example source file, test file, and documentation file. If you do not need these files, you can delete them:
 
@@ -333,7 +333,7 @@ Move essential files to run local tests
         $ rm tests/test_functions.py
         $ rm doc/source/api/<package-name>.example_package.rst
 
-#. Commit the changes:
+#. If any files have been added or modified in the way you like, you can add and commit the changes. Otherwise, you can skip this step:
 
     .. code-block:: bash
 

--- a/doc/source/tutorials/tutorial-level-5-migration.rst
+++ b/doc/source/tutorials/tutorial-level-5-migration.rst
@@ -322,6 +322,14 @@ Move essential files to run local tests
 
         $ git status
 
+#. By default, ``scikit-package`` generates an example source file, test file, and documentation file. If you do not need these files, you can delete them:
+
+    .. code-block:: bash
+
+        $ rm src/<package-name>/functions.py
+        $ rm tests/test_functions.py
+        $ rm doc/source/api/<package-name>.example_package.rst
+
 #. Commit the changes:
 
     .. code-block:: bash
@@ -330,6 +338,20 @@ Move essential files to run local tests
         $ git add tests && git commit -m "skpkg: migrate tests folder"
 
 #. Manually list the dependencies under ``requirements/pip.txt``, ``requirements/tests.txt``, ``requirements/docs.txt``, ``requirements/conda.txt``.
+
+   - ``pip.txt``
+     Core runtime dependencies needed to use the package.
+
+   - ``test.txt``
+     Packages required for running tests and checking coverage.
+
+   - ``docs.txt``
+     Dependencies for building documentation.
+
+   - ``conda.txt``
+     Base environment packages best installed via ``conda``.
+   - ``build.txt`` *(optional)*
+     Build tools needed for non-Python components (e.g., C/C++ libraries, compilers). Only include if your package requires compilation.
 
 #. Delete ``requirements/build.txt`` if your package only contains Python code.
 

--- a/doc/source/tutorials/tutorial-level-5-migration.rst
+++ b/doc/source/tutorials/tutorial-level-5-migration.rst
@@ -315,8 +315,8 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        cp -n -r ../src src/
-        cp -n -r ../tests tests/
+        cp -n -r ../src/* src/
+        cp -n -r ../tests/* tests/
 
     .. seealso::
 

--- a/doc/source/tutorials/tutorial-level-5-migration.rst
+++ b/doc/source/tutorials/tutorial-level-5-migration.rst
@@ -482,19 +482,34 @@ Move documentation files
 
     .. code-block:: bash
 
-        $ cp -n -r ../doc/source/* ./doc/source.
+        $ cp -n -r ../doc/source/* ./doc/source
 
     .. note::
 
         If files are moved to a different path like ``doc/manual/source`` (old) to ``doc/source`` (new), open the project in IDE and do a global search (ctrl + shift + f) for ``../`` or ``..`` and modify all relative path instances.
+
+#. Once again, ``scikit-package`` creates template files in the ``doc/source`` folder. If you do not need these files, you can delete them:
+
+    .. code-block:: bash
+
+        $ rm doc/source/getting-started.rst
+        $ rm -r doc/source/img/
+        $ rm -r doc/source/snippets/
+
+#. Some files in ``doc/source`` may have been modified by ``scikit-package``. Manually check these files and decide whether you want to keep the changes made by ``scikit-package`` or not. After doing this, you can add and commit changes (if applicable):
+
+    .. code-block:: bash
+
+        $ git add doc/source
+        $ git commit -m "skpkg: migrate doc/source files"
 
 #. Ensure the documentation can be built locally:
 
     .. code-block:: bash
 
         $ conda install --file requirements/docs.txt
-        $ cd doc && make html
-        & open _build/html/index.html
+        $ cd doc && make html && open build/html/index.html
+
 
 #. Add and commit the changes:
 
@@ -569,10 +584,10 @@ Step 3. Final check
 
 #. Ask the project maintainer to create a PR from ``upstream/migration`` to ``upstream/main``
 
-#. After the PR is merged to ``upstream/main``, archive the old repository by naming it:
+#. After the PR is merged to ``upstream/main``, archive the old repository by changing its name:
 
     .. code-block:: bash
-
+        $ cd ..
         $ mv <package-name> <package-name>-archive
 
 #. Clone the latest version of the package from the remote:

--- a/doc/source/tutorials/tutorial-level-5-migration.rst
+++ b/doc/source/tutorials/tutorial-level-5-migration.rst
@@ -334,10 +334,10 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        $ git add src && git commit -m "skpkg: mirate src folder"
+        $ git add src && git commit -m "skpkg: migrate src folder"
         $ git add tests && git commit -m "skpkg: migrate tests folder"
 
-#. Manually list the dependencies under ``requirements/pip.txt``, ``requirements/tests.txt``, ``requirements/docs.txt``, ``requirements/conda.txt``.
+#. Manually list the dependencies under ``requirements/pip.txt``, ``requirements/tests.txt``, ``requirements/docs.txt``, ``requirements/conda.txt``, and ``requirements/build.txt`` (see below for more details on this file).
 
    - ``pip.txt``
      Core runtime dependencies needed to use the package.
@@ -409,21 +409,21 @@ Setup GitHub Actions
 
     .. code-block:: bash
 
-        git add requirements
-        git commit -m "skpkg: list dependencies in requirements folder"
+        $ git add requirements
+        $ git commit -m "skpkg: list dependencies in requirements folder"
 
 #. Add and commit ``pyproject.toml``:
 
     .. code-block:: bash
 
-        git add pyproject.toml
-        git commit -m "skpkg: add pyproject.toml"
+        $ git add pyproject.toml
+        $ git commit -m "skpkg: add pyproject.toml"
 
 #. Push the changes to the ``setup-CI`` branch:
 
     .. code-block:: bash
 
-        git push origin setup-CI
+        $ git push origin setup-CI
 
 #. Create a PR from ``username/setup-CI`` to ``upstream/migration``.
 

--- a/doc/source/tutorials/tutorial-level-5-migration.rst
+++ b/doc/source/tutorials/tutorial-level-5-migration.rst
@@ -69,6 +69,11 @@ Run ``black`` in your codebase
     .. code-block:: bash
 
         $ git checkout -b black-edits
+
+#. If you do not have a ``pyproject.toml`` file, you can create one by running the following command:
+
+    .. code-block:: bash
+
         $ touch pyproject.toml
 
 #. Copy and paste the following content at the bottom of ``pyproject.toml``:
@@ -154,11 +159,18 @@ Apply pre-commit auto-fixes without manual edits
 
         $ pre-commit run --all-files
 
-#. Add the changes to the ``pre-commit-auto`` branch:
+#. Run ``git status`` to see all the files that have been modified by ``pre-commit`` hooks:
+
+      .. code-block:: bash
+
+          $ git status
+
+#. When you run ``git status``, you will see the package you created under ``Untracked files`` with the package name you gave. At this step, you want to add and commit everything **except** this package. To do so, run the following commands and replace ``<package-name>`` with the name of your package:
 
     .. code-block:: bash
 
-        $ git add . && git commit -m "style: apply pre-commit hooks with no manual edits"``
+        $ git add -- . ':!<package-name>'
+        $ git commit -m "style: apply pre-commit hooks with no manual edits"
 
 #. Push the changes to the remote repository:
 
@@ -192,7 +204,7 @@ Here, instead of fixing all errors at once, we will address each type of error o
         $ git checkout migration
         $ git pull upstream migration
 
-#. Create a new branch that will be used to fix the type of errors:
+#. Create a new branch that will be used to fix the type of errors like flake8 or codespell:
 
     .. code-block:: bash
 
@@ -271,7 +283,7 @@ Move essential files to run local tests
 
     .. code-block::
 
-        $ mv ../<package-name>/.git .
+        $ mv ../.git .
 
 #. See a list of files that have been (1) untracked, (2) deleted, (3) modified:
 
@@ -285,7 +297,7 @@ Move essential files to run local tests
         - ``deleted`` are files in the old directory but the files that are not in the new directory. At the moment, most of the ``src`` and ``tests`` and ``doc`` files will be in this category. We will move them from the old to the new directory in the next few steps.
         - ``modified`` are files that that exist both in the old and the new directory, while the scikig-package has made changes to them.
 
-#. Create a new branch called called ``setup-CI``:
+#. Create a new branch called ``setup-CI``:
 
     .. code-block:: bash
 
@@ -297,8 +309,8 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        $ cp -n -r ../src .
-        $ cp -n -r ../tests .
+        $ cp -n -r ../src src
+        $ cp -n -r ../tests tests
 
     .. seealso::
 

--- a/doc/source/tutorials/tutorial-level-5-migration.rst
+++ b/doc/source/tutorials/tutorial-level-5-migration.rst
@@ -197,11 +197,16 @@ The package will most likely have failed ``pre-commit`` hooks. We will manually 
 
 Here, instead of fixing all errors at once, we will address each type of error one at a time.  For example, a branch called ``pre-commit-spelling`` may contain spelling fixes, while another branch, ``pre-commit-flake8-line`` fixes of line length errors raised by flake8.
 
-#. Sync with the ``upstream/migration`` branch:
+#. To get the ``migration`` branch from ``upstream/migration`` and track it, run the following commands:
 
     .. code-block:: bash
 
-        $ git checkout -b migration upstream/migration
+        $ git checkout --track upstream/migration
+
+#. Make sure everything is sync'd with the ``upstream/migration`` branch:
+
+    .. code-block:: bash
+
         $ git pull upstream migration
 
 #. Create a new branch that will be used to fix the type of errors like flake8 or codespell:

--- a/doc/source/tutorials/tutorial-level-5-migration.rst
+++ b/doc/source/tutorials/tutorial-level-5-migration.rst
@@ -309,8 +309,8 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        $ cp -n -r ../src .
-        $ cp -n -r ../tests .
+        $ cp -n -r ../src src/
+        $ cp -n -r ../tests tests/
 
     .. seealso::
 
@@ -321,6 +321,9 @@ Move essential files to run local tests
     .. code-block:: bash
 
         $ git status
+
+.. attention::
+    If you see any files under ``src`` or ``tests`` that are modified, **manually check these files** and decide whether you want to keep the changes made by ``scikit-package`` or not.
 
 #. By default, ``scikit-package`` generates an example source file, test file, and documentation file. If you do not need these files, you can delete them:
 

--- a/doc/source/tutorials/tutorial-level-5-migration.rst
+++ b/doc/source/tutorials/tutorial-level-5-migration.rst
@@ -36,9 +36,9 @@ Step 1. Pre-commit workflow
 
     .. code-block::
 
-        $ git clone <URL-of-the-forked-repo>
-        $ cd <package-name>
-        $ git remote add upstream <URL-of-the-original-repo>
+        git clone <URL-of-the-forked-repo>
+        cd <package-name>
+        git remote add upstream <URL-of-the-original-repo>
 
     .. note::
 
@@ -53,28 +53,28 @@ Run ``black`` in your codebase
 
     .. code-block:: bash
 
-        $ git checkout main
-        $ git pull upstream main
+        git checkout main
+        git pull upstream main
 
 
 #. Activate the conda environment and install ``black``:
 
     .. code-block:: bash
 
-        $ conda activate skpkg-env
-        $ conda install black
+        conda activate skpkg-env
+        conda install black
 
 #. Create a new branch called ``black-edits`` and create a new file called ``pyproject.toml``:
 
     .. code-block:: bash
 
-        $ git checkout -b black-edits
+        git checkout -b black-edits
 
 #. If you do not have a ``pyproject.toml`` file, you can create one by running the following command:
 
     .. code-block:: bash
 
-        $ touch pyproject.toml
+        touch pyproject.toml
 
 #. Copy and paste the following content at the bottom of ``pyproject.toml``:
 
@@ -104,7 +104,7 @@ Run ``black`` in your codebase
 
     .. code-block:: bash
 
-        $ black .
+        black .
 
     .. seealso:: To skip certain files, add them under the ``exclude`` section in the ``pyproject.toml``.
 
@@ -112,9 +112,9 @@ Run ``black`` in your codebase
 
     .. code-block:: bash
 
-        $ git add .
-        $ git commit -m "skpkg: apply black to all files in the project directory"
-        $ git push origin black-edits
+        git add .
+        git commit -m "skpkg: apply black to all files in the project directory"
+        git push origin black-edits
 
 #. Create a PR from ``username/black-edits`` to ``upstream/main``.
 
@@ -131,52 +131,52 @@ Apply pre-commit auto-fixes without manual edits
 
     .. code-block:: bash
 
-        $ git checkout main && git pull upstream main
+        git checkout main && git pull upstream main
 
 #. Create a new branch called ``pre-commit-auto``:
 
     .. code-block:: bash
 
-        $ git checkout -b pre-commit-auto
+        git checkout -b pre-commit-auto
 
 #. Create a new package using ``scikit-package``:
 
     .. code-block:: bash
 
-        $ package create public
+        package create public
 
 #. Copy the ``pre-commit`` configuration files from the new to the old directory:
 
     .. code-block:: bash
 
-        $ cp <package-name>/.pre-commit-config.yaml .
-        $ cp <package-name>/.isort.cfg .
-        $ cp <package-name>/.flake8 .
+        cp <package-name>/.pre-commit-config.yaml .
+        cp <package-name>/.isort.cfg .
+        cp <package-name>/.flake8 .
 
 #. Trigger hooks and auto-fixes without manual edits:
 
     .. code-block:: bash
 
-        $ pre-commit run --all-files
+        pre-commit run --all-files
 
 #. Run ``git status`` to see all the files that have been modified by ``pre-commit`` hooks:
 
       .. code-block:: bash
 
-          $ git status
+          git status
 
 #. When you run ``git status``, you will see the package you created under ``Untracked files`` with the package name you gave. At this step, you want to add and commit everything **except** this package. To do so, run the following commands and replace ``<package-name>`` with the name of your package:
 
     .. code-block:: bash
 
-        $ git add -- . ':!<package-name>'
-        $ git commit -m "style: apply pre-commit hooks with no manual edits"
+        git add -- . ':!<package-name>'
+        git commit -m "style: apply pre-commit hooks with no manual edits"
 
 #. Push the changes to the remote repository:
 
     .. code-block:: bash
 
-        $ git push origin pre-commit-auto
+        git push origin pre-commit-auto
 
 #. Create a PR from ``username/pre-commit-auto`` to ``upstream/migration``. The PR title can be ``skpkg: apply pre-commit to project directory with no manual edits``.
 
@@ -201,20 +201,20 @@ Here, instead of fixing all errors at once, we will address each type of error o
 
     .. code-block:: bash
 
-        $ git fetch upstream migration
-        $ git checkout --track upstream/migration
+        git fetch upstream migration
+        git checkout --track upstream/migration
 
 #. Make sure everything is sync'd with the ``upstream/migration`` branch:
 
     .. code-block:: bash
 
-        $ git pull upstream migration
+        git pull upstream migration
 
 #. Create a new branch that will be used to fix the type of errors like flake8 or codespell:
 
     .. code-block:: bash
 
-        $ git checkout -b pre-commit-<theme>
+        git checkout -b pre-commit-<theme>
 
 #. Run ``pre-commit run --all-files`` to see the errors:
 
@@ -230,9 +230,9 @@ Here, instead of fixing all errors at once, we will address each type of error o
 
     .. code-block:: bash
 
-        $ git add <files-modified-to-fix-error>
-        $ git commit -m "skpkg: fix <theme> errors"
-        $ git push origin pre-commit-<theme>
+        git add <files-modified-to-fix-error>
+        git commit -m "skpkg: fix <theme> errors"
+        git push origin pre-commit-<theme>
 
 #. Create a PR from ``username/pre-commit-<theme>`` to ``upstream/migration``. The PR title can be ``skpkg: fix <theme> errors``.
 
@@ -242,15 +242,15 @@ Here, instead of fixing all errors at once, we will address each type of error o
 
     .. code-block:: bash
 
-        $ git checkout migration
-        $ git pull upstream migration
-        $ git checkout -b pre-commit-<another-theme>
+        git checkout migration
+        git pull upstream migration
+        git checkout -b pre-commit-<another-theme>
 
 #. Are all the PRs merged and do all ``pre-commit`` hooks pass? If so, you are ready for the next section! Before that, let's automatically trigger ``pre-commit`` hooks going forward:
 
     .. code-block:: bash
 
-        $ pre-commit install
+        pre-commit install
 
 Setup pre-commit CI
 ^^^^^^^^^^^^^^^^^^^
@@ -277,25 +277,25 @@ Move essential files to run local tests
 
     .. code-block::
 
-        $ git checkout migration && git pull upstream migration
+        git checkout migration && git pull upstream migration
 
 #. Move into the new directory created by ``scikit-package``:
 
     .. code-block::
 
-        $ cd <package-name>
+        cd <package-name>
 
 #. Move ``.git`` from the old (``..``) to the new directory (``.``):
 
     .. code-block::
 
-        $ mv ../.git .
+        mv ../.git .
 
 #. See a list of files that have been (1) untracked, (2) deleted, (3) modified:
 
     .. code-block::
 
-        $ git status
+        git status
 
     .. seealso::
 
@@ -315,8 +315,8 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        $ cp -n -r ../src src/
-        $ cp -n -r ../tests tests/
+        cp -n -r ../src src/
+        cp -n -r ../tests tests/
 
     .. seealso::
 
@@ -326,7 +326,7 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        $ git status
+        git status
 
     .. attention::
         If you see any files under ``src`` or ``tests`` that are modified, **manually check these files** and decide whether you want to keep the changes made by ``scikit-package`` or not.
@@ -335,16 +335,16 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        $ rm src/<package-name>/functions.py
-        $ rm tests/test_functions.py
-        $ rm doc/source/api/<package-name>.example_package.rst
+        rm src/<package-name>/functions.py
+        rm tests/test_functions.py
+        rm doc/source/api/<package-name>.example_package.rst
 
 #. If any files have been added or modified in the way you like, you can add and commit the changes. Otherwise, you can skip this step:
 
     .. code-block:: bash
 
-        $ git add src && git commit -m "skpkg: migrate src folder"
-        $ git add tests && git commit -m "skpkg: migrate tests folder"
+        git add src && git commit -m "skpkg: migrate src folder"
+        git add tests && git commit -m "skpkg: migrate tests folder"
 
 #. Manually list the dependencies under ``requirements/pip.txt``, ``requirements/tests.txt``, ``requirements/docs.txt``, ``requirements/conda.txt``, and ``requirements/build.txt`` (see below for more details on this file).
 
@@ -366,25 +366,25 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        $ rm requirements/build.txt
+        rm requirements/build.txt
 
 #. Add and commit the changes in the  ``requirements`` folder:
 
     .. code-block:: bash
 
-        $ git add requirements
-        $ git commit -m "skpkg: list dependencies in requirements folder"
+        git add requirements
+        git commit -m "skpkg: list dependencies in requirements folder"
 
 #. Test your package from a new conda environment:
 
     .. code-block:: bash
 
-        $ conda create -n <package-name>-env python=3.13 \
+        conda create -n <package-name>-env python=3.13 \
             --file requirements/conda.txt \
             --file requirements/test.txt
-        $ conda activate <package-name>-env
-        $ pip install -e . --no-deps
-        $ pytest
+        conda activate <package-name>-env
+        pip install -e . --no-deps
+        pytest
 
     .. note::
 
@@ -408,8 +408,8 @@ Setup GitHub Actions
 
     .. code-block:: bash
 
-        $ git add .github/workflows/tests-on-pr.yml .gitignore
-        $ git commit -m "skpkg: add CI and issue/PR templates"
+        git add .github/workflows/tests-on-pr.yml .gitignore
+        git commit -m "skpkg: add CI and issue/PR templates"
 
     .. Attention::
         If your package does not support the latest Python version of |PYTHON_MAX_VERSION|, you will need to specify the Python version supported by your package. Follow the instructions here to set the Python version under ``.github/workflows`` in :ref:`github-actions-python-versions`.
@@ -418,21 +418,21 @@ Setup GitHub Actions
 
     .. code-block:: bash
 
-        $ git add requirements
-        $ git commit -m "skpkg: list dependencies in requirements folder"
+        git add requirements
+        git commit -m "skpkg: list dependencies in requirements folder"
 
 #. Add and commit ``pyproject.toml``:
 
     .. code-block:: bash
 
-        $ git add pyproject.toml
-        $ git commit -m "skpkg: add pyproject.toml"
+        git add pyproject.toml
+        git commit -m "skpkg: add pyproject.toml"
 
 #. Push the changes to the ``setup-CI`` branch:
 
     .. code-block:: bash
 
-        $ git push origin setup-CI
+        git push origin setup-CI
 
 #. Create a PR from ``username/setup-CI`` to ``upstream/migration``.
 
@@ -449,18 +449,18 @@ Add configuration files
 
     .. code-block:: bash
 
-        $ git checkout migration
-        $ git pull upstream migration
-        $ git checkout -b config
+        git checkout migration
+        git pull upstream migration
+        git checkout -b config
 
 #. Add and commit configuration files:
 
     .. code-block:: bash
 
-        $ git add .pre-commit-config.yaml .codespell .flake8 .isort.cfg
-        $ git commit -m "skpkg: add config files for pre-commit "
-        $ git add .readthedocs.yaml .codecov.yml .github
-        $ git commit -m "skpkg: add config files readthedocs, codecov, GitHub"
+        git add .pre-commit-config.yaml .codespell .flake8 .isort.cfg
+        git commit -m "skpkg: add config files for pre-commit "
+        git add .readthedocs.yaml .codecov.yml .github
+        git commit -m "skpkg: add config files readthedocs, codecov, GitHub"
 
 #. Create a PR from ``username/config`` to ``upstream/migration``.
 
@@ -475,15 +475,15 @@ Move documentation files
 
     .. code-block:: bash
 
-        $ git checkout migration
-        $ git pull upstream migration
-        $ git checkout -b doc
+        git checkout migration
+        git pull upstream migration
+        git checkout -b doc
 
 #. Copy documentation from the old to the new repository:
 
     .. code-block:: bash
 
-        $ cp -n -r ../doc/source/* ./doc/source
+        cp -n -r ../doc/source/* ./doc/source
 
     .. note::
 
@@ -493,31 +493,31 @@ Move documentation files
 
     .. code-block:: bash
 
-        $ rm doc/source/getting-started.rst
-        $ rm -r doc/source/img/
-        $ rm -r doc/source/snippets/
+        rm doc/source/getting-started.rst
+        rm -r doc/source/img/
+        rm -r doc/source/snippets/
 
 #. Some files in ``doc/source`` may have been modified by ``scikit-package``. Manually check these files and decide whether you want to keep the changes made by ``scikit-package`` or not. After doing this, you can add and commit changes (if applicable):
 
     .. code-block:: bash
 
-        $ git add doc/source
-        $ git commit -m "skpkg: migrate doc/source files"
+        git add doc/source
+        git commit -m "skpkg: migrate doc/source files"
 
 #. Ensure the documentation can be built locally:
 
     .. code-block:: bash
 
-        $ conda install --file requirements/docs.txt
-        $ cd doc && make html && open build/html/index.html
+        conda install --file requirements/docs.txt
+        cd doc && make html && open build/html/index.html
 
 
 #. Add and commit the changes:
 
     .. code-block:: bash
 
-        $ git add doc
-        $ git commit -m "skpkg: migrate documentation"
+        git add doc
+        git commit -m "skpkg: migrate documentation"
 
 #. By hand, migrate content over to ``README.rst``.
 
@@ -529,18 +529,18 @@ Move documentation files
 
     .. code-block:: bash
 
-        $ git add AUTHORS.rst CHANGELOG.rst CODE_OF_CONDUCT.rst LICENSE.rst
-        $ git commit -m "skpkg: add config files for authors, changelog, code of conduct, license"
-        $ git add MANIFEST.in
-        $ git commit -m "skpkg: add MANIFEST.in"
-        $ git add README.rst
-        $ git commit -m "skpkg: add README.rst"
+        git add AUTHORS.rst CHANGELOG.rst CODE_OF_CONDUCT.rst LICENSE.rst
+        git commit -m "skpkg: add config files for authors, changelog, code of conduct, license"
+        git add MANIFEST.in
+        git commit -m "skpkg: add MANIFEST.in"
+        git add README.rst
+        git commit -m "skpkg: add README.rst"
 
 #. Create a news file:
 
     .. code-block:: bash
 
-        $ cp news/TEMPLATE.rst news/doc.rst
+        cp news/TEMPLATE.rst news/doc.rst
 
 #. In ``news/docs..rst``, add the following content under ``Fixed:``:
 
@@ -562,8 +562,8 @@ Move documentation files
 
     .. code-block:: bash
 
-        $ git add news
-        $ git commit -m "skpkg: add news files"
+        git add news
+        git commit -m "skpkg: add news files"
 
 #. Create a PR from ``usernmae/doc`` to ``upstream/migration``.
 
@@ -588,25 +588,25 @@ Step 3. Final check
 #. After the PR is merged to ``upstream/main``, archive the old repository by changing its name:
 
     .. code-block:: bash
-        $ cd ..
-        $ mv <package-name> <package-name>-archive
+        cd ..
+        mv <package-name> <package-name>-archive
 
 #. Clone the latest version of the package from the remote:
 
     .. code-block:: bash
 
-        $ cd ~/dev
-        $ git clone <URL-of-the-forked-repo>
-        $ git remote add upstream <URL-of-the-original-repo>
-        $ git pull upstream main
+        cd ~/dev
+        git clone <URL-of-the-forked-repo>
+        git remote add upstream <URL-of-the-original-repo>
+        git pull upstream main
 
 #. Now, you should be able to run the following to test your package!
 
     .. code-block:: bash
 
-        $ conda activate <package-name>-env
-        $ pytest
-        $ pre-commit run --all-files
+        conda activate <package-name>-env
+        pytest
+        pre-commit run --all-files
 
 #. Congratulations! You are done with migration!
 

--- a/doc/source/tutorials/tutorial-level-5-migration.rst
+++ b/doc/source/tutorials/tutorial-level-5-migration.rst
@@ -588,6 +588,7 @@ Step 3. Final check
 #. After the PR is merged to ``upstream/main``, archive the old repository by changing its name:
 
     .. code-block:: bash
+
         cd ..
         mv <package-name> <package-name>-archive
 

--- a/doc/source/tutorials/tutorial-level-5-migration.rst
+++ b/doc/source/tutorials/tutorial-level-5-migration.rst
@@ -201,7 +201,7 @@ Here, instead of fixing all errors at once, we will address each type of error o
 
     .. code-block:: bash
 
-        $ git checkout migration
+        $ git checkout -b migration upstream/migration
         $ git pull upstream migration
 
 #. Create a new branch that will be used to fix the type of errors like flake8 or codespell:
@@ -309,8 +309,8 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        $ cp -n -r ../src src
-        $ cp -n -r ../tests tests
+        $ cp -n -r ../src .
+        $ cp -n -r ../tests .
 
     .. seealso::
 

--- a/doc/source/tutorials/tutorial-level-5-migration.rst
+++ b/doc/source/tutorials/tutorial-level-5-migration.rst
@@ -201,6 +201,7 @@ Here, instead of fixing all errors at once, we will address each type of error o
 
     .. code-block:: bash
 
+        $ git fetch upstream migration
         $ git checkout --track upstream/migration
 
 #. Make sure everything is sync'd with the ``upstream/migration`` branch:

--- a/news/migration-docs-edits.rst
+++ b/news/migration-docs-edits.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Correct typos and mistakes in migration portion of documentation.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
As per the convo we had during the hackathon, I found a decent middle-ground for running pre-commit with the `scikit-package` config files. See screenshot for these steps. running `git add -- . '!:<package-name>'` is a quick way that adds all the edits made by pre-commit and excludes the package created by `package create public`. I think this keeps things simple for the users and runs pre-commit early in the workflow. This works for packages that have already been cut in the past and packages that have never be cut at all. 

Additionally, I made some other changes that are more clear for beginner users.

closes #528 

<img width="925" alt="Screenshot 2025-06-10 at 12 41 08 PM" src="https://github.com/user-attachments/assets/c4a5f4fa-fec8-43a2-bd9b-fb92d902f5bb" />
