### PR TITLE
docs: remove `$` from codeblocks

### DIFF
--- a/doc/source/release-guides/conda-forge.rst
+++ b/doc/source/release-guides/conda-forge.rst
@@ -188,7 +188,7 @@ Generate ``meta.yaml`` by following ``Step 1`` and ``Step 2`` under ``conda-forg
 
     .. code-block:: bash
 
-       $ conda install -c conda-forge/label/<package-name>_rc -c conda-forge <package-name>
+       conda install -c conda-forge/label/<package-name>_rc -c conda-forge <package-name>
 
 For more, read the conda-forge official documentation for pre-release: https://conda-forge.org/docs/maintainer/knowledge_base/#pre-release-builds
 

--- a/doc/source/release-guides/pypi-github.rst
+++ b/doc/source/release-guides/pypi-github.rst
@@ -49,9 +49,9 @@ Start pre-release
 
    .. code-block:: bash
 
-      $ conda install vulture
+      conda install vulture
       #### Example outputs after running vulture ####
-      $ vulture src/ tests/
+      vulture src/ tests/
       tests/test_module1.py:22: unused import 'os' (100% confidence)
 
    Review the output and remove or suppress unused code when it is not needed to keep the release clean and maintainable.
@@ -62,8 +62,8 @@ Start pre-release
 
       # For pre-release, use *.*.*-rc.* e.g., 1.0.0-rc.0
       # rc stands for release candidate
-      $ git tag <version>-rc.<rc-number>
-      $ git push upstream <version>-rc.<rc-number>
+      git tag <version>-rc.<rc-number>
+      git push upstream <version>-rc.<rc-number>
 
 #. Done! Once the tag is pushed, visit the :guilabel:`Actions` tab in the repository to monitor the CI progress.
 
@@ -85,8 +85,8 @@ Full release after pre-release
    .. code-block:: bash
 
       # For release, use *.*.* e.g., 1.0.0
-      $ git tag <version>
-      $ git push upstream <version>
+      git tag <version>
+      git push upstream <version>
 
 #. Notice that ``CHANGELOG.rst`` is also updated with the new release version and the documentation is built under the ``gh-pages`` branch.
 

--- a/doc/source/snippets/conda-env-setup-simple.rst
+++ b/doc/source/snippets/conda-env-setup-simple.rst
@@ -11,23 +11,23 @@ Virtual environments allow you to create isolated environments, each with their 
 
     .. code-block:: bash
 
-        $ conda config --add channels conda-forge
+        conda config --add channels conda-forge
 
 #. Now, let's create a new environment and install ``numpy`` in it. ``numpy`` will be sourced from the ``conda-forge`` channel. Replace ``<project-name>`` with the name of your project.
 
     .. code-block:: bash
 
         # Create a new environment and install numpy in the environment
-        $ conda create -n <project-name>-env numpy
+        conda create -n <project-name>-env numpy
 
         # Activate the environment
-        $ conda activate <project-name>-env
+        conda activate <project-name>-env
 
 #. Let's check if the installation was successful. You can do this by running the following command:
 
     .. code-block:: bash
 
-        $ python --version
+        python --version
 
     .. note::
 
@@ -36,6 +36,6 @@ Virtual environments allow you to create isolated environments, each with their 
         .. code-block:: bash
 
             # For Windows (PowerShell)
-            $ conda init powershell
+            conda init powershell
 
 #. Done!

--- a/doc/source/snippets/doc-local-build.rst
+++ b/doc/source/snippets/doc-local-build.rst
@@ -2,26 +2,26 @@
 
     .. code-block:: bash
 
-        $ conda install --file requirements/docs.txt
+        conda install --file requirements/docs.txt
 
 #. Enter into the ``doc`` project directory and render documentation:
 
     .. code-block:: bash
 
-        $ cd doc
-        $ make html
+        cd doc
+        make html
 
 #. Open the rendered documentation via web browser:
 
     .. code-block:: bash
 
-        $ open _build/html/index.html
+        open _build/html/index.html
 
 #. Here is a shortcut if you want to use it from the root directory of the project:
 
     .. code-block:: bash
 
-        $ cd doc && make html && open _build/html/index.html && cd ..
+        cd doc && make html && open _build/html/index.html && cd ..
 
     .. seealso::
 
@@ -35,13 +35,13 @@
 
         .. code-block:: bash
 
-            $ source ~/.bashrc
+            source ~/.bashrc
 
         Now, you can simply enter the ``doc`` command in your terminal to build and open the documentation:
 
         .. code-block:: bash
 
-            $ doc
+            doc
 
 (Optional for macOS/Linux only) Do you want to re-render documentation without running ``doc`` command every time? You can use ``sphinx-reload``.
 
@@ -49,13 +49,13 @@
 
         .. code-block:: bash
 
-            $ conda install --file requirements/docs.txt
-            $ pip install sphinx-reload
+            conda install --file requirements/docs.txt
+            pip install sphinx-reload
 
     #. Run the following command to start live-reloading:
 
         .. code-block:: bash
 
-            $ sphinx-reload doc
+            sphinx-reload doc
 
     #. Now, each time you make changes to the documentation, it will be automatically reloaded in your web browser.

--- a/doc/source/snippets/github-upload-all-remaining-files-level-4.rst
+++ b/doc/source/snippets/github-upload-all-remaining-files-level-4.rst
@@ -5,17 +5,17 @@ While we previously uploaded the ``README`` file to the remote GitHub ``main`` r
 
     .. code-block:: bash
 
-        $ git checkout main
-        $ git pull origin main
+        git checkout main
+        git pull origin main
 
 #. Checkout a new branch called ``skpkg-system`` from the ``main`` branch:
 
     .. code-block:: bash
 
-        $ git checkout -b skpkg-system
-        $ git add .
-        $ git commit -m "skpkg: start a new project with skpkg"
-        $ git push -u origin skpkg-system
+        git checkout -b skpkg-system
+        git add .
+        git commit -m "skpkg: start a new project with skpkg"
+        git push -u origin skpkg-system
 
 #. Visit your GitHub repository online.
 
@@ -37,10 +37,10 @@ While we previously uploaded the ``README`` file to the remote GitHub ``main`` r
 
         .. code-block:: bash
 
-         $ git pull origin skpkg-system
-         $ git add <file-modified-that-fixes-pre-commit-error>
-         $ git commit -m "chore: <your commit message>"
-         $ git push
+         git pull origin skpkg-system
+         git add <file-modified-that-fixes-pre-commit-error>
+         git commit -m "chore: <your commit message>"
+         git push
 
 #. Click :guilabel:`Files changed` in the PR to to review the new files added to the repository.
 

--- a/doc/source/snippets/github-upload-all-remaining-files-level-5.rst
+++ b/doc/source/snippets/github-upload-all-remaining-files-level-5.rst
@@ -4,23 +4,23 @@ Before we upload anything to the ``main`` branch, we want to check the incoming 
 
     .. code-block:: bash
 
-        $ git checkout main
-        $ git pull origin main
+        git checkout main
+        git pull origin main
 
 #. Setup pre-commit locally so that code is linted before a commit is made:
 
     .. code-block:: bash
 
-        $ pre-commit install
+        pre-commit install
 
 #. Checkout a new branch called ``skpkg-public`` from the ``main`` branch:
 
     .. code-block:: bash
 
-        $ git checkout -b skpkg-public
-        $ git add .
-        $ git commit -m "skpkg: start a new level 5 project with skpkg"
-        $ git push -u origin skpkg-public
+        git checkout -b skpkg-public
+        git add .
+        git commit -m "skpkg: start a new level 5 project with skpkg"
+        git push -u origin skpkg-public
 
     .. note::
 

--- a/doc/source/snippets/github-upload-readme-pre-commit.rst
+++ b/doc/source/snippets/github-upload-readme-pre-commit.rst
@@ -4,18 +4,18 @@ At the moment, the GitHub repository is empty. Let's create a local branch calle
 
     .. code-block:: bash
 
-        $ git init
-        $ git remote add origin <your-github-repo-url>
-        $ git branch -M main
+        git init
+        git remote add origin <your-github-repo-url>
+        git branch -M main
 
 #. Commit the README file to the Git database and push it to the remote GitHub repository:
 
     .. code-block:: bash
 
-        $ git add README.md   # If you are using Level 4
-        $ git add README.rst  # If you are using Level 5
-        $ git commit -m "docs: add README"
-        $ git push -u origin main
+        git add README.md   # If you are using Level 4
+        git add README.rst  # If you are using Level 5
+        git commit -m "docs: add README"
+        git push -u origin main
 
     .. note:: What's ``origin``?
 

--- a/doc/source/snippets/github-workflow-moving-forward.rst
+++ b/doc/source/snippets/github-workflow-moving-forward.rst
@@ -5,8 +5,8 @@ Assume that you have successfully followed the previous steps. Now, you want to 
 
     .. code-block:: bash
 
-        $ git checkout main
-        $ git pull origin main
+        git checkout main
+        git pull origin main
 
     .. note::
 
@@ -16,26 +16,26 @@ Assume that you have successfully followed the previous steps. Now, you want to 
 
     .. code-block:: bash
 
-        $ git log
+        git log
 
 #. Create a new local branch from the ``main`` branch. Let's call this branch ``skpkg``:
 
     .. code-block:: bash
 
-        $ git checkout -b <branch-name>
+        git checkout -b <branch-name>
 
 #. Modify any file that you want. Then, stage and commit the changes:
 
     .. code-block:: bash
 
-        $ git add <file-modified-added-deleted>
-        $ git commit -m "feat: <your commit message>"
+        git add <file-modified-added-deleted>
+        git commit -m "feat: <your commit message>"
 
 #. Push your code from ``<branch-name>`` to the remote ``<branch-name>`` branch:
 
     .. code-block:: bash
 
-        $ git push --set-upstream origin <branch-name>
+        git push --set-upstream origin <branch-name>
 
 #. Visit your GitHub repository.
 

--- a/doc/source/snippets/news-file-format.rst
+++ b/doc/source/snippets/news-file-format.rst
@@ -14,7 +14,7 @@ How do I create a news file?
 
     .. code-block:: bash
 
-        $ package add news --add -m "<Describe the main feature added in the PR.>"
+        package add news --add -m "<Describe the main feature added in the PR.>"
 
     .. note::
 
@@ -85,7 +85,7 @@ Yes. In this case, we want to communicate to the reviewer(s) the reason it shoul
 
     .. code-block:: bash
 
-        $ package add news -n -m "<brief-reason>."
+        package add news -n -m "<brief-reason>."
 
 You will see a new file has been created: ``news/<branch-name>.rst``
 

--- a/doc/source/snippets/package-install-test-local.rst
+++ b/doc/source/snippets/package-install-test-local.rst
@@ -2,7 +2,7 @@
 
     .. code-block:: bash
 
-        $ conda create -n my-package-env python=3.13 \
+        conda create -n my-package-env python=3.13 \
             --file requirements/conda.txt \
             --file requirements/test.txt
 
@@ -10,13 +10,13 @@
 
     .. code-block:: bash
 
-        $ conda activate my-package-env
+        conda activate my-package-env
 
 #. Build and install the package locally:
 
     .. code-block:: bash
 
-        $ pip install -e . --no-deps
+        pip install -e . --no-deps
 
     .. note:: What is the ``-e`` flag?
 
@@ -34,7 +34,7 @@
 
     .. code-block:: bash
 
-        $ pytest
+        pytest
 
 #. Ensure tests all pass with green checkmarks. Notice that in ``tests/test_functions.py``, we are importing the locally installed package.
 

--- a/doc/source/snippets/pre-commit-local-setup.rst
+++ b/doc/source/snippets/pre-commit-local-setup.rst
@@ -4,14 +4,14 @@ First, let's ensure that before we upload any of our code to the remote reposito
 
     .. code-block:: bash
 
-        $ pre-commit install
+        pre-commit install
 
 #. Let's now stage and commit the code:
 
     .. code-block:: bash
 
-        $ git add .
-        $ git commit -m "skpkg: initial commit of a new project"
+        git add .
+        git commit -m "skpkg: initial commit of a new project"
 
 #. Ensure that all of the ``pre-commit`` hooks pass:
 
@@ -29,7 +29,7 @@ First, let's ensure that before we upload any of our code to the remote reposito
 
     .. code-block:: bash
 
-        $ git log
+        git log
 
     .. note::
 

--- a/doc/source/snippets/scikit-installation.rst
+++ b/doc/source/snippets/scikit-installation.rst
@@ -7,13 +7,13 @@ Install ``scikit-package`` with conda
 
     .. code-block:: bash
 
-        $ conda config --add channels conda-forge
+        conda config --add channels conda-forge
 
 #. Create a new conda environment ``skpkg-env`` and install ``scikit-package`` and ``pre-commit`` simultaneously by running the following command:
 
     .. code-block:: bash
 
-        $ conda create -n skpkg-env scikit-package pre-commit
+        conda create -n skpkg-env scikit-package pre-commit
 
     .. note::
 
@@ -22,10 +22,10 @@ Install ``scikit-package`` with conda
 
     .. code-block:: bash
 
-        $ conda activate skpkg-env
+        conda activate skpkg-env
 
 #. Confirm that you have the latest version of ``scikit-package`` available on GitHub:
 
     .. code-block:: bash
 
-        $ pip show scikit-package
+        pip show scikit-package

--- a/doc/source/support/frequently-asked-questions.rst
+++ b/doc/source/support/frequently-asked-questions.rst
@@ -154,13 +154,13 @@ Here are the steps you can follow to override the default values for Level 5 usa
 
   .. code-block:: bash
 
-    $ cd ~
+    cd ~
 
 2. Create ``.skpkgrc``.
 
   .. code-block:: bash
 
-    $ touch .skpkgrc
+    touch .skpkgrc
 
 3. Edit ``.skpkgrc``. Copy and paste the following snippets to ``.skpkgrc``.
 
@@ -192,7 +192,7 @@ The scikit-package configuration file is located in ``~/.skpkgrc`` by default. Y
 
 .. code-block:: bash
 
-   $ export SKPKG_CONFIG_FILE=/path/to/config
+   export SKPKG_CONFIG_FILE=/path/to/config
 
 
 Release
@@ -610,8 +610,8 @@ Here is how you can add the conda-forge channel to your conda configuration and 
 
 .. code-block:: bash
 
-  $ conda config --add channels conda-forge
-  $ conda install scikit-package
+  conda config --add channels conda-forge
+  conda install scikit-package
 
 The first command adds the ``conda-forge`` channel to the conda configuration, allowing users to install packages from this channel. The second command installs the ``scikit-package`` package from the ``conda-forge`` channel. https://anaconda.org/conda-forge/scikit-package
 
@@ -804,19 +804,19 @@ Add the following line to ``~/.bashrc`` or ``~/.zshrc`` file:
 
 .. code-block:: bash
 
-    $ alias cpnews="cp news/TEMPLATE.rst news/$(git rev-parse --abbrev-ref HEAD).rst"
+    alias cpnews="cp news/TEMPLATE.rst news/$(git rev-parse --abbrev-ref HEAD).rst"
 
 Optionally, if you also want to apply ``git add`` for the ``news/<branch-name>.rst`` created, you can use the following command instead:
 
 .. code-block:: bash
 
-    $ alias cpnews='cp news/TEMPLATE.rst news/$(git rev-parse --abbrev-ref HEAD).rst && git add news/$(git rev-parse --abbrev-ref HEAD).rst'
+    alias cpnews='cp news/TEMPLATE.rst news/$(git rev-parse --abbrev-ref HEAD).rst && git add news/$(git rev-parse --abbrev-ref HEAD).rst'
 
 Run the following command to apply the shell configuration:
 
 .. code-block:: bash
 
-    $ source ~/.bashrc
+    source ~/.bashrc
 
 Now, whenever you want to create a news file for the PR, simply navigate to the top-level directory in the project and type ``cpnews`` on the command line.
 

--- a/doc/source/tutorials/tutorial-level-1-2-3.rst
+++ b/doc/source/tutorials/tutorial-level-1-2-3.rst
@@ -44,11 +44,11 @@ Example
      .. code-block:: bash
 
           # Create a new directory
-          $ mkdir skpkg-tutorials
+          mkdir skpkg-tutorials
           # Navigate into the directory
-          $ cd skpkg-tutorials
+          cd skpkg-tutorials
           # Create a new file
-          $ touch shared_functions.py
+          touch shared_functions.py
 
 #. Copy and paste the code block below into ``shared_functions.py``:
 
@@ -74,8 +74,8 @@ Example
 
      .. code-block:: bash
 
-          $ conda activate <env-name>
-          $ python shared_functions.py
+          conda activate <env-name>
+          python shared_functions.py
 
 #. You should see the outputs of 11 and 83 printed.
 
@@ -113,8 +113,8 @@ Example code
 
      .. code-block:: bash
 
-          $ cd skpkg-tutorials
-          $ touch file_one.py file_two.py
+          cd skpkg-tutorials
+          touch file_one.py file_two.py
 
 #. Copy and paste the following to ``file_one.py``:
 
@@ -153,9 +153,9 @@ Example code
 
      .. code-block:: bash
 
-          $ conda activate <env-name>
-          $ python file_one.py
-          $ python file_two.py
+          conda activate <env-name>
+          python file_one.py
+          python file_two.py
 
 What's next?
 ^^^^^^^^^^^^
@@ -183,14 +183,14 @@ Initiate a new project with ``scikit-package``
 
      .. code-block:: bash
 
-          $ conda activate <env-name>
-          $ conda install scikit-package
+          conda activate <env-name>
+          conda install scikit-package
 
 #. Create a new project by running the following command:
 
      .. code-block:: bash
 
-          $ package create workspace
+          package create workspace
 
      .. note::
 
@@ -206,7 +206,7 @@ Initiate a new project with ``scikit-package``
 
      .. code-block:: bash
 
-          $ cd data-analysis-project
+          cd data-analysis-project
 
 #. Confirm you have the following folder structure generated:
 
@@ -246,7 +246,7 @@ Before running code, you need to set the ``PYTHONPATH`` environment variable to 
 
      .. code-block:: bash
 
-          $ pwd
+          pwd
 
      For a macOS user, it will print something like ``/Users/imac/dev/data-analysis-projects``.
 
@@ -255,17 +255,17 @@ Before running code, you need to set the ``PYTHONPATH`` environment variable to 
      .. code-block:: bash
 
           # For macOS/Linux/Git for Windows user
-          $ export PYTHONPATH="${PYTHONPATH}:<path-to-your-workspace-folder>"
+          export PYTHONPATH="${PYTHONPATH}:<path-to-your-workspace-folder>"
 
           # For Windows (Powershell) user
-          $ env:PYTHONPATH = "$env:PYTHONPATH;<path-to-your-workspace-folder>"
+          env:PYTHONPATH = "$env:PYTHONPATH;<path-to-your-workspace-folder>"
 
 #. Install the dependencies:
 
      .. code-block:: bash
 
-          $ conda activate <env-name>
-          $ conda install --file requirements.txt
+          conda activate <env-name>
+          conda install --file requirements.txt
 
      .. note::
 
@@ -275,15 +275,15 @@ Before running code, you need to set the ``PYTHONPATH`` environment variable to 
 
      .. code-block:: bash
 
-          $ cd proj-one
-          $ python proj_one_code.py
+          cd proj-one
+          python proj_one_code.py
 
 #. Also run the tests:
 
      .. code-block:: bash
 
-          $ cd ..        # go back to the parent directory to run pytest
-          $ pytest
+          cd ..        # go back to the parent directory to run pytest
+          pytest
 
      You should see the output similar to:
 
@@ -316,8 +316,8 @@ more readable. ``pre-commit`` is a tool that helps you with that.
 
      .. code-block:: bash
 
-          $ conda activate <env-name>
-          $ conda install pre-commit
+          conda activate <env-name>
+          conda install pre-commit
 
      .. note::
 
@@ -327,8 +327,8 @@ more readable. ``pre-commit`` is a tool that helps you with that.
 
      .. code-block:: bash
 
-          $ git init
-          $ git add .
+          git init
+          git add .
 
      .. note::
 
@@ -374,19 +374,19 @@ To avoid retyping this command every time you open a new terminal, you can add i
 
           # For macOS/Linux/Git for Windows:
           # bash shell
-          $ nano ~/.bashrc
+          nano ~/.bashrc
           # For Windows PowerShell:
-          $ notepad $PROFILE
+          notepad $PROFILE
 
 #. Add the command to set ``PYTHONPATH`` at the end of the file:
 
      .. code-block:: bash
 
           # For macOS/Linux/Git for Windows
-          $ echo 'export PYTHONPATH="${PYTHONPATH}:/path/to/your/workspace_folder"'
+          echo 'export PYTHONPATH="${PYTHONPATH}:/path/to/your/workspace_folder"'
 
           # For Windows (PowerShell)
-          $ echo '$env:PYTHONPATH = "$env:PYTHONPATH;/path/to/your/workspace_folder"'
+          echo '$env:PYTHONPATH = "$env:PYTHONPATH;/path/to/your/workspace_folder"'
 
 #. Save the file.
 
@@ -395,9 +395,9 @@ To avoid retyping this command every time you open a new terminal, you can add i
      .. code-block:: bash
 
           # For macOS/Linux/Git for Windows:
-          $ source ~/.bashrc
+          source ~/.bashrc
           # For Windows PowerShell:
-          $ . $PROFILE
+          . $PROFILE
 
 #. Restart your terminal.
 
@@ -412,15 +412,15 @@ Here is an example of how to create an additional project under the same workspa
 
      .. code-block:: bash
 
-          $ cd data-analysis-project
+          cd data-analysis-project
 
 #. Create a new directory and two files in it:
 
      .. code-block:: bash
 
-          $ mkdir proj-two
-          $ cd proj-two
-          $ touch __init__.py proj_two_code.py
+          mkdir proj-two
+          cd proj-two
+          touch __init__.py proj_two_code.py
 
 #. Add your code to ``proj_two_code.py``.
 
@@ -428,7 +428,7 @@ Here is an example of how to create an additional project under the same workspa
 
      .. code-block:: bash
 
-          $ cd proj-two
-          $ python proj_two_code.py
+          cd proj-two
+          python proj_two_code.py
 
 #. Done! You can also start writing tests for this new project in the ``tests`` folder by creating a new file named ``test_proj_two_code.py``.

--- a/doc/source/tutorials/tutorial-level-4-to-5.rst
+++ b/doc/source/tutorials/tutorial-level-4-to-5.rst
@@ -38,15 +38,15 @@ Create a new project with ``scikit-package``
 
     .. code-block:: bash
 
-        $ cd <project-name>
-        $ git checkout main
-        $ git pull origin main
+        cd <project-name>
+        git checkout main
+        git pull origin main
 
 #. Create a new project with ``scikit-package`` using the Level 5 ``public`` template:
 
     .. code-block:: bash
 
-        $ package create public
+        package create public
 
     .. important::
 
@@ -60,7 +60,7 @@ Create a new project with ``scikit-package``
 
     .. code-block:: bash
 
-        $ cd <package-name>
+        cd <package-name>
 
 #. Check that you have the following nested folder structure. Here is the structure. We will go through each file and folder:
 
@@ -94,35 +94,35 @@ Migration files from Level 4 to Level 5
 
     .. code-block:: bash
 
-        $ cd <package-name>
+        cd <package-name>
 
 #. Move the local ``git`` repository from the Level 4 (``..``) to the Level 5 folder (``.``):
 
     .. code-block:: bash
 
-        $ mv ../.git .
+        mv ../.git .
 
 #. Move the ``src`` and ``tests`` folders from Level 4 to Level 5:
 
     .. code-block:: bash
 
-        $ cp -n -r ../src .
-        $ cp -n -r ../tests .
+        cp -n -r ../src .
+        cp -n -r ../tests .
 
 #. Copy the requirements files from Level 4 to Level 5:
 
     .. code-block:: bash
 
-        $ cp ../requirements/conda.txt ./requirements/conda.txt
-        $ cp ../requirements/pip.txt ./requirements/pip.txt
-        $ cp ../requirements/test.txt ./requirements/test.txt
+        cp ../requirements/conda.txt ./requirements/conda.txt
+        cp ../requirements/pip.txt ./requirements/pip.txt
+        cp ../requirements/test.txt ./requirements/test.txt
 
 #. At this point, you should be able to install the package locally and test it using your existing conda environment:
 
     .. code-block:: bash
 
-        $ conda activate  <package-name>-env
-        $ pytest tests
+        conda activate  <package-name>-env
+        pytest tests
 
 #. Once the tests pass, let's manually migrate hand-written files like ``README.md`` from Level 4 to Level 5.
 

--- a/doc/source/tutorials/tutorial-level-4.rst
+++ b/doc/source/tutorials/tutorial-level-4.rst
@@ -51,7 +51,7 @@ Create a new project with ``scikit-package``
 
     .. code-block:: bash
 
-        $ package create system
+        package create system
 
 #. Respond to the following prompts:
 
@@ -82,7 +82,7 @@ Create a new project with ``scikit-package``
 
     .. code-block:: bash
 
-        $ cd my-package
+        cd my-package
 
 #. Confirm that you have the following folder structure shown below:
 

--- a/doc/source/tutorials/tutorial-level-5-migration.rst
+++ b/doc/source/tutorials/tutorial-level-5-migration.rst
@@ -36,9 +36,9 @@ Step 1. Pre-commit workflow
 
     .. code-block::
 
-        $ git clone <URL-of-the-forked-repo>
-        $ cd <package-name>
-        $ git remote add upstream <URL-of-the-original-repo>
+        git clone <URL-of-the-forked-repo>
+        cd <package-name>
+        git remote add upstream <URL-of-the-original-repo>
 
     .. note::
 
@@ -53,23 +53,23 @@ Run ``black`` in your codebase
 
     .. code-block:: bash
 
-        $ git checkout main
-        $ git pull upstream main
+        git checkout main
+        git pull upstream main
 
 
 #. Activate the conda environment and install ``black``:
 
     .. code-block:: bash
 
-        $ conda activate skpkg-env
-        $ conda install black
+        conda activate skpkg-env
+        conda install black
 
 #. Create a new branch called ``black-edits`` and create a new file called ``pyproject.toml``:
 
     .. code-block:: bash
 
-        $ git checkout -b black-edits
-        $ touch pyproject.toml
+        git checkout -b black-edits
+        touch pyproject.toml
 
 #. Copy and paste the following content at the bottom of ``pyproject.toml``:
 
@@ -99,7 +99,7 @@ Run ``black`` in your codebase
 
     .. code-block:: bash
 
-        $ black .
+        black .
 
     .. seealso:: To skip certain files, add them under the ``exclude`` section in the ``pyproject.toml``.
 
@@ -107,9 +107,9 @@ Run ``black`` in your codebase
 
     .. code-block:: bash
 
-        $ git add .
-        $ git commit -m "skpkg: apply black to all files in the project directory"
-        $ git push origin black-edits
+        git add .
+        git commit -m "skpkg: apply black to all files in the project directory"
+        git push origin black-edits
 
 #. Create a PR from ``username/black-edits`` to ``upstream/main``.
 
@@ -126,45 +126,45 @@ Apply pre-commit auto-fixes without manual edits
 
     .. code-block:: bash
 
-        $ git checkout main && git pull upstream main
+        git checkout main && git pull upstream main
 
 #. Create a new branch called ``pre-commit-auto``:
 
     .. code-block:: bash
 
-        $ git checkout -b pre-commit-auto
+        git checkout -b pre-commit-auto
 
 #. Create a new package using ``scikit-package``:
 
     .. code-block:: bash
 
-        $ package create public
+        package create public
 
 #. Copy the ``pre-commit`` configuration files from the new to the old directory:
 
     .. code-block:: bash
 
-        $ cp <package-name>/.pre-commit-config.yaml .
-        $ cp <package-name>/.isort.cfg .
-        $ cp <package-name>/.flake8 .
+        cp <package-name>/.pre-commit-config.yaml .
+        cp <package-name>/.isort.cfg .
+        cp <package-name>/.flake8 .
 
 #. Trigger hooks and auto-fixes without manual edits:
 
     .. code-block:: bash
 
-        $ pre-commit run --all-files
+        pre-commit run --all-files
 
 #. Add the changes to the ``pre-commit-auto`` branch:
 
     .. code-block:: bash
 
-        $ git add . && git commit -m "style: apply pre-commit hooks with no manual edits"``
+        git add . && git commit -m "style: apply pre-commit hooks with no manual edits"``
 
 #. Push the changes to the remote repository:
 
     .. code-block:: bash
 
-        $ git push origin pre-commit-auto
+        git push origin pre-commit-auto
 
 #. Create a PR from ``username/pre-commit-auto`` to ``upstream/migration``. The PR title can be ``skpkg: apply pre-commit to project directory with no manual edits``.
 
@@ -189,14 +189,14 @@ Here, instead of fixing all errors at once, we will address each type of error o
 
     .. code-block:: bash
 
-        $ git checkout migration
-        $ git pull upstream migration
+        git checkout migration
+        git pull upstream migration
 
 #. Create a new branch that will be used to fix the type of errors:
 
     .. code-block:: bash
 
-        $ git checkout -b pre-commit-<theme>
+        git checkout -b pre-commit-<theme>
 
 #. Run ``pre-commit run --all-files`` to see the errors:
 
@@ -212,9 +212,9 @@ Here, instead of fixing all errors at once, we will address each type of error o
 
     .. code-block:: bash
 
-        $ git add <files-modified-to-fix-error>
-        $ git commit -m "skpkg: fix <theme> errors"
-        $ git push origin pre-commit-<theme>
+        git add <files-modified-to-fix-error>
+        git commit -m "skpkg: fix <theme> errors"
+        git push origin pre-commit-<theme>
 
 #. Create a PR from ``username/pre-commit-<theme>`` to ``upstream/migration``. The PR title can be ``skpkg: fix <theme> errors``.
 
@@ -224,15 +224,15 @@ Here, instead of fixing all errors at once, we will address each type of error o
 
     .. code-block:: bash
 
-        $ git checkout migration
-        $ git pull upstream migration
-        $ git checkout -b pre-commit-<another-theme>
+        git checkout migration
+        git pull upstream migration
+        git checkout -b pre-commit-<another-theme>
 
 #. Are all the PRs merged and do all ``pre-commit`` hooks pass? If so, you are ready for the next section! Before that, let's automatically trigger ``pre-commit`` hooks going forward:
 
     .. code-block:: bash
 
-        $ pre-commit install
+        pre-commit install
 
 Setup pre-commit CI
 ^^^^^^^^^^^^^^^^^^^
@@ -259,25 +259,25 @@ Move essential files to run local tests
 
     .. code-block::
 
-        $ git checkout migration && git pull upstream migration
+        git checkout migration && git pull upstream migration
 
 #. Move into the new directory created by ``scikit-package``:
 
     .. code-block::
 
-        $ cd <package-name>
+        cd <package-name>
 
 #. Move ``.git`` from the old (``..``) to the new directory (``.``):
 
     .. code-block::
 
-        $ mv ../<package-name>/.git .
+        mv ../<package-name>/.git .
 
 #. See a list of files that have been (1) untracked, (2) deleted, (3) modified:
 
     .. code-block::
 
-        $ git status
+        git status
 
     .. seealso::
 
@@ -297,8 +297,8 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        $ cp -n -r ../src .
-        $ cp -n -r ../tests .
+        cp -n -r ../src .
+        cp -n -r ../tests .
 
     .. seealso::
 
@@ -308,14 +308,14 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        $ git status
+        git status
 
 #. Commit the changes:
 
     .. code-block:: bash
 
-        $ git add src && git commit -m "skpkg: mirate src folder"
-        $ git add tests && git commit -m "skpkg: migrate tests folder"
+        git add src && git commit -m "skpkg: mirate src folder"
+        git add tests && git commit -m "skpkg: migrate tests folder"
 
 #. Manually list the dependencies under ``requirements/pip.txt``, ``requirements/tests.txt``, ``requirements/docs.txt``, ``requirements/conda.txt``.
 
@@ -323,25 +323,25 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        $ rm requirements/build.txt
+        rm requirements/build.txt
 
 #. Add and commit the changes in the  ``requirements`` folder:
 
     .. code-block:: bash
 
-        $ git add requirements
-        $ git commit -m "skpkg: list dependencies in requirements folder"
+        git add requirements
+        git commit -m "skpkg: list dependencies in requirements folder"
 
 #. Test your package from a new conda environment:
 
     .. code-block:: bash
 
-        $ conda create -n <package-name>-env python=3.13 \
+        conda create -n <package-name>-env python=3.13 \
             --file requirements/conda.txt \
             --file requirements/test.txt
-        $ conda activate <package-name>-env
-        $ pip install -e . --no-deps
-        $ pytest
+        conda activate <package-name>-env
+        pip install -e . --no-deps
+        pytest
 
     .. note::
 
@@ -365,8 +365,8 @@ Setup GitHub Actions
 
     .. code-block:: bash
 
-        $ git add .github/workflows/tests-on-pr.yml .gitignore
-        $ git commit -m "skpkg: add CI and issue/PR templates"
+        git add .github/workflows/tests-on-pr.yml .gitignore
+        git commit -m "skpkg: add CI and issue/PR templates"
 
     .. Attention::
         If your package does not support the latest Python version of |PYTHON_MAX_VERSION|, you will need to specify the Python version supported by your package. Follow the instructions here to set the Python version under ``.github/workflows`` in :ref:`github-actions-python-versions`.
@@ -406,18 +406,18 @@ Add configuration files
 
     .. code-block:: bash
 
-        $ git checkout migration
-        $ git pull upstream migration
-        $ git checkout -b config
+        git checkout migration
+        git pull upstream migration
+        git checkout -b config
 
 #. Add and commit configuration files:
 
     .. code-block:: bash
 
-        $ git add .pre-commit-config.yaml .codespell .flake8 .isort.cfg
-        $ git commit -m "skpkg: add config files for pre-commit "
-        $ git add .readthedocs.yaml .codecov.yml .github
-        $ git commit -m "skpkg: add config files readthedocs, codecov, GitHub"
+        git add .pre-commit-config.yaml .codespell .flake8 .isort.cfg
+        git commit -m "skpkg: add config files for pre-commit "
+        git add .readthedocs.yaml .codecov.yml .github
+        git commit -m "skpkg: add config files readthedocs, codecov, GitHub"
 
 #. Create a PR from ``username/config`` to ``upstream/migration``.
 
@@ -432,15 +432,15 @@ Move documentation files
 
     .. code-block:: bash
 
-        $ git checkout migration
-        $ git pull upstream migration
-        $ git checkout -b doc
+        git checkout migration
+        git pull upstream migration
+        git checkout -b doc
 
 #. Copy documentation from the old to the new repository:
 
     .. code-block:: bash
 
-        $ cp -n -r ../doc/source/* ./doc/source.
+        cp -n -r ../doc/source/* ./doc/source.
 
     .. note::
 
@@ -450,16 +450,16 @@ Move documentation files
 
     .. code-block:: bash
 
-        $ conda install --file requirements/docs.txt
-        $ cd doc && make html
+        conda install --file requirements/docs.txt
+        cd doc && make html
         & open _build/html/index.html
 
 #. Add and commit the changes:
 
     .. code-block:: bash
 
-        $ git add doc
-        $ git commit -m "skpkg: migrate documentation"
+        git add doc
+        git commit -m "skpkg: migrate documentation"
 
 #. By hand, migrate content over to ``README.rst``.
 
@@ -471,18 +471,18 @@ Move documentation files
 
     .. code-block:: bash
 
-        $ git add AUTHORS.rst CHANGELOG.rst CODE_OF_CONDUCT.rst LICENSE.rst
-        $ git commit -m "skpkg: add config files for authors, changelog, code of conduct, license"
-        $ git add MANIFEST.in
-        $ git commit -m "skpkg: add MANIFEST.in"
-        $ git add README.rst
-        $ git commit -m "skpkg: add README.rst"
+        git add AUTHORS.rst CHANGELOG.rst CODE_OF_CONDUCT.rst LICENSE.rst
+        git commit -m "skpkg: add config files for authors, changelog, code of conduct, license"
+        git add MANIFEST.in
+        git commit -m "skpkg: add MANIFEST.in"
+        git add README.rst
+        git commit -m "skpkg: add README.rst"
 
 #. Create a news file:
 
     .. code-block:: bash
 
-        $ cp news/TEMPLATE.rst news/doc.rst
+        cp news/TEMPLATE.rst news/doc.rst
 
 #. In ``news/docs..rst``, add the following content under ``Fixed:``:
 
@@ -504,8 +504,8 @@ Move documentation files
 
     .. code-block:: bash
 
-        $ git add news
-        $ git commit -m "skpkg: add news files"
+        git add news
+        git commit -m "skpkg: add news files"
 
 #. Create a PR from ``usernmae/doc`` to ``upstream/migration``.
 
@@ -531,24 +531,24 @@ Step 3. Final check
 
     .. code-block:: bash
 
-        $ mv <package-name> <package-name>-archive
+        mv <package-name> <package-name>-archive
 
 #. Clone the latest version of the package from the remote:
 
     .. code-block:: bash
 
-        $ cd ~/dev
-        $ git clone <URL-of-the-forked-repo>
-        $ git remote add upstream <URL-of-the-original-repo>
-        $ git pull upstream main
+        cd ~/dev
+        git clone <URL-of-the-forked-repo>
+        git remote add upstream <URL-of-the-original-repo>
+        git pull upstream main
 
 #. Now, you should be able to run the following to test your package!
 
     .. code-block:: bash
 
-        $ conda activate <package-name>-env
-        $ pytest
-        $ pre-commit run --all-files
+        conda activate <package-name>-env
+        pytest
+        pre-commit run --all-files
 
 #. Congratulations! You are done with migration!
 

--- a/doc/source/tutorials/tutorial-level-5-migration.rst
+++ b/doc/source/tutorials/tutorial-level-5-migration.rst
@@ -36,9 +36,9 @@ Step 1. Pre-commit workflow
 
     .. code-block::
 
-        git clone <URL-of-the-forked-repo>
-        cd <package-name>
-        git remote add upstream <URL-of-the-original-repo>
+        $ git clone <URL-of-the-forked-repo>
+        $ cd <package-name>
+        $ git remote add upstream <URL-of-the-original-repo>
 
     .. note::
 
@@ -53,23 +53,23 @@ Run ``black`` in your codebase
 
     .. code-block:: bash
 
-        git checkout main
-        git pull upstream main
+        $ git checkout main
+        $ git pull upstream main
 
 
 #. Activate the conda environment and install ``black``:
 
     .. code-block:: bash
 
-        conda activate skpkg-env
-        conda install black
+        $ conda activate skpkg-env
+        $ conda install black
 
 #. Create a new branch called ``black-edits`` and create a new file called ``pyproject.toml``:
 
     .. code-block:: bash
 
-        git checkout -b black-edits
-        touch pyproject.toml
+        $ git checkout -b black-edits
+        $ touch pyproject.toml
 
 #. Copy and paste the following content at the bottom of ``pyproject.toml``:
 
@@ -99,7 +99,7 @@ Run ``black`` in your codebase
 
     .. code-block:: bash
 
-        black .
+        $ black .
 
     .. seealso:: To skip certain files, add them under the ``exclude`` section in the ``pyproject.toml``.
 
@@ -107,9 +107,9 @@ Run ``black`` in your codebase
 
     .. code-block:: bash
 
-        git add .
-        git commit -m "skpkg: apply black to all files in the project directory"
-        git push origin black-edits
+        $ git add .
+        $ git commit -m "skpkg: apply black to all files in the project directory"
+        $ git push origin black-edits
 
 #. Create a PR from ``username/black-edits`` to ``upstream/main``.
 
@@ -126,45 +126,45 @@ Apply pre-commit auto-fixes without manual edits
 
     .. code-block:: bash
 
-        git checkout main && git pull upstream main
+        $ git checkout main && git pull upstream main
 
 #. Create a new branch called ``pre-commit-auto``:
 
     .. code-block:: bash
 
-        git checkout -b pre-commit-auto
+        $ git checkout -b pre-commit-auto
 
 #. Create a new package using ``scikit-package``:
 
     .. code-block:: bash
 
-        package create public
+        $ package create public
 
 #. Copy the ``pre-commit`` configuration files from the new to the old directory:
 
     .. code-block:: bash
 
-        cp <package-name>/.pre-commit-config.yaml .
-        cp <package-name>/.isort.cfg .
-        cp <package-name>/.flake8 .
+        $ cp <package-name>/.pre-commit-config.yaml .
+        $ cp <package-name>/.isort.cfg .
+        $ cp <package-name>/.flake8 .
 
 #. Trigger hooks and auto-fixes without manual edits:
 
     .. code-block:: bash
 
-        pre-commit run --all-files
+        $ pre-commit run --all-files
 
 #. Add the changes to the ``pre-commit-auto`` branch:
 
     .. code-block:: bash
 
-        git add . && git commit -m "style: apply pre-commit hooks with no manual edits"``
+        $ git add . && git commit -m "style: apply pre-commit hooks with no manual edits"``
 
 #. Push the changes to the remote repository:
 
     .. code-block:: bash
 
-        git push origin pre-commit-auto
+        $ git push origin pre-commit-auto
 
 #. Create a PR from ``username/pre-commit-auto`` to ``upstream/migration``. The PR title can be ``skpkg: apply pre-commit to project directory with no manual edits``.
 
@@ -189,14 +189,14 @@ Here, instead of fixing all errors at once, we will address each type of error o
 
     .. code-block:: bash
 
-        git checkout migration
-        git pull upstream migration
+        $ git checkout migration
+        $ git pull upstream migration
 
 #. Create a new branch that will be used to fix the type of errors:
 
     .. code-block:: bash
 
-        git checkout -b pre-commit-<theme>
+        $ git checkout -b pre-commit-<theme>
 
 #. Run ``pre-commit run --all-files`` to see the errors:
 
@@ -212,9 +212,9 @@ Here, instead of fixing all errors at once, we will address each type of error o
 
     .. code-block:: bash
 
-        git add <files-modified-to-fix-error>
-        git commit -m "skpkg: fix <theme> errors"
-        git push origin pre-commit-<theme>
+        $ git add <files-modified-to-fix-error>
+        $ git commit -m "skpkg: fix <theme> errors"
+        $ git push origin pre-commit-<theme>
 
 #. Create a PR from ``username/pre-commit-<theme>`` to ``upstream/migration``. The PR title can be ``skpkg: fix <theme> errors``.
 
@@ -224,9 +224,9 @@ Here, instead of fixing all errors at once, we will address each type of error o
 
     .. code-block:: bash
 
-        git checkout migration
-        git pull upstream migration
-        git checkout -b pre-commit-<another-theme>
+        $ git checkout migration
+        $ git pull upstream migration
+        $ git checkout -b pre-commit-<another-theme>
 
 #. Are all the PRs merged and do all ``pre-commit`` hooks pass? If so, you are ready for the next section! Before that, let's automatically trigger ``pre-commit`` hooks going forward:
 
@@ -259,25 +259,25 @@ Move essential files to run local tests
 
     .. code-block::
 
-        git checkout migration && git pull upstream migration
+        $ git checkout migration && git pull upstream migration
 
 #. Move into the new directory created by ``scikit-package``:
 
     .. code-block::
 
-        cd <package-name>
+        $ cd <package-name>
 
 #. Move ``.git`` from the old (``..``) to the new directory (``.``):
 
     .. code-block::
 
-        mv ../<package-name>/.git .
+        $ mv ../<package-name>/.git .
 
 #. See a list of files that have been (1) untracked, (2) deleted, (3) modified:
 
     .. code-block::
 
-        git status
+        $ git status
 
     .. seealso::
 
@@ -289,7 +289,7 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        git checkout -b setup-CI
+        $ git checkout -b setup-CI
 
 #. Now you will move ``src`` and ``tests`` folders in the following steps.
 
@@ -297,8 +297,8 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        cp -n -r ../src .
-        cp -n -r ../tests .
+        $ cp -n -r ../src .
+        $ cp -n -r ../tests .
 
     .. seealso::
 
@@ -308,14 +308,14 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        git status
+        $ git status
 
 #. Commit the changes:
 
     .. code-block:: bash
 
-        git add src && git commit -m "skpkg: mirate src folder"
-        git add tests && git commit -m "skpkg: migrate tests folder"
+        $ git add src && git commit -m "skpkg: mirate src folder"
+        $ git add tests && git commit -m "skpkg: migrate tests folder"
 
 #. Manually list the dependencies under ``requirements/pip.txt``, ``requirements/tests.txt``, ``requirements/docs.txt``, ``requirements/conda.txt``.
 
@@ -323,25 +323,25 @@ Move essential files to run local tests
 
     .. code-block:: bash
 
-        rm requirements/build.txt
+        $ rm requirements/build.txt
 
 #. Add and commit the changes in the  ``requirements`` folder:
 
     .. code-block:: bash
 
-        git add requirements
-        git commit -m "skpkg: list dependencies in requirements folder"
+        $ git add requirements
+        $ git commit -m "skpkg: list dependencies in requirements folder"
 
 #. Test your package from a new conda environment:
 
     .. code-block:: bash
 
-        conda create -n <package-name>-env python=3.13 \
+        $ conda create -n <package-name>-env python=3.13 \
             --file requirements/conda.txt \
             --file requirements/test.txt
-        conda activate <package-name>-env
-        pip install -e . --no-deps
-        pytest
+        $ conda activate <package-name>-env
+        $ pip install -e . --no-deps
+        $ pytest
 
     .. note::
 
@@ -365,8 +365,8 @@ Setup GitHub Actions
 
     .. code-block:: bash
 
-        git add .github/workflows/tests-on-pr.yml .gitignore
-        git commit -m "skpkg: add CI and issue/PR templates"
+        $ git add .github/workflows/tests-on-pr.yml .gitignore
+        $ git commit -m "skpkg: add CI and issue/PR templates"
 
     .. Attention::
         If your package does not support the latest Python version of |PYTHON_MAX_VERSION|, you will need to specify the Python version supported by your package. Follow the instructions here to set the Python version under ``.github/workflows`` in :ref:`github-actions-python-versions`.
@@ -375,21 +375,21 @@ Setup GitHub Actions
 
     .. code-block:: bash
 
-        git add requirements
-        git commit -m "skpkg: list dependencies in requirements folder"
+        $ git add requirements
+        $ git commit -m "skpkg: list dependencies in requirements folder"
 
 #. Add and commit ``pyproject.toml``:
 
     .. code-block:: bash
 
-        git add pyproject.toml
-        git commit -m "skpkg: add pyproject.toml"
+        $ git add pyproject.toml
+        $ git commit -m "skpkg: add pyproject.toml"
 
 #. Push the changes to the ``setup-CI`` branch:
 
     .. code-block:: bash
 
-        git push origin setup-CI
+        $ git push origin setup-CI
 
 #. Create a PR from ``username/setup-CI`` to ``upstream/migration``.
 
@@ -406,18 +406,18 @@ Add configuration files
 
     .. code-block:: bash
 
-        git checkout migration
-        git pull upstream migration
-        git checkout -b config
+        $ git checkout migration
+        $ git pull upstream migration
+        $ git checkout -b config
 
 #. Add and commit configuration files:
 
     .. code-block:: bash
 
-        git add .pre-commit-config.yaml .codespell .flake8 .isort.cfg
-        git commit -m "skpkg: add config files for pre-commit "
-        git add .readthedocs.yaml .codecov.yml .github
-        git commit -m "skpkg: add config files readthedocs, codecov, GitHub"
+        $ git add .pre-commit-config.yaml .codespell .flake8 .isort.cfg
+        $ git commit -m "skpkg: add config files for pre-commit "
+        $ git add .readthedocs.yaml .codecov.yml .github
+        $ git commit -m "skpkg: add config files readthedocs, codecov, GitHub"
 
 #. Create a PR from ``username/config`` to ``upstream/migration``.
 
@@ -432,15 +432,15 @@ Move documentation files
 
     .. code-block:: bash
 
-        git checkout migration
-        git pull upstream migration
-        git checkout -b doc
+        $ git checkout migration
+        $ git pull upstream migration
+        $ git checkout -b doc
 
 #. Copy documentation from the old to the new repository:
 
     .. code-block:: bash
 
-        cp -n -r ../doc/source/* ./doc/source.
+        $ cp -n -r ../doc/source/* ./doc/source.
 
     .. note::
 
@@ -450,16 +450,16 @@ Move documentation files
 
     .. code-block:: bash
 
-        conda install --file requirements/docs.txt
-        cd doc && make html
+        $ conda install --file requirements/docs.txt
+        $ cd doc && make html
         & open _build/html/index.html
 
 #. Add and commit the changes:
 
     .. code-block:: bash
 
-        git add doc
-        git commit -m "skpkg: migrate documentation"
+        $ git add doc
+        $ git commit -m "skpkg: migrate documentation"
 
 #. By hand, migrate content over to ``README.rst``.
 
@@ -471,18 +471,18 @@ Move documentation files
 
     .. code-block:: bash
 
-        git add AUTHORS.rst CHANGELOG.rst CODE_OF_CONDUCT.rst LICENSE.rst
-        git commit -m "skpkg: add config files for authors, changelog, code of conduct, license"
-        git add MANIFEST.in
-        git commit -m "skpkg: add MANIFEST.in"
-        git add README.rst
-        git commit -m "skpkg: add README.rst"
+        $ git add AUTHORS.rst CHANGELOG.rst CODE_OF_CONDUCT.rst LICENSE.rst
+        $ git commit -m "skpkg: add config files for authors, changelog, code of conduct, license"
+        $ git add MANIFEST.in
+        $ git commit -m "skpkg: add MANIFEST.in"
+        $ git add README.rst
+        $ git commit -m "skpkg: add README.rst"
 
 #. Create a news file:
 
     .. code-block:: bash
 
-        cp news/TEMPLATE.rst news/doc.rst
+        $ cp news/TEMPLATE.rst news/doc.rst
 
 #. In ``news/docs..rst``, add the following content under ``Fixed:``:
 
@@ -504,8 +504,8 @@ Move documentation files
 
     .. code-block:: bash
 
-        git add news
-        git commit -m "skpkg: add news files"
+        $ git add news
+        $ git commit -m "skpkg: add news files"
 
 #. Create a PR from ``usernmae/doc`` to ``upstream/migration``.
 
@@ -531,24 +531,24 @@ Step 3. Final check
 
     .. code-block:: bash
 
-        mv <package-name> <package-name>-archive
+        $ mv <package-name> <package-name>-archive
 
 #. Clone the latest version of the package from the remote:
 
     .. code-block:: bash
 
-        cd ~/dev
-        git clone <URL-of-the-forked-repo>
-        git remote add upstream <URL-of-the-original-repo>
-        git pull upstream main
+        $ cd ~/dev
+        $ git clone <URL-of-the-forked-repo>
+        $ git remote add upstream <URL-of-the-original-repo>
+        $ git pull upstream main
 
 #. Now, you should be able to run the following to test your package!
 
     .. code-block:: bash
 
-        conda activate <package-name>-env
-        pytest
-        pre-commit run --all-files
+        $ conda activate <package-name>-env
+        $ pytest
+        $ pre-commit run --all-files
 
 #. Congratulations! You are done with migration!
 

--- a/doc/source/tutorials/tutorial-level-5.rst
+++ b/doc/source/tutorials/tutorial-level-5.rst
@@ -33,7 +33,7 @@ Create a new project with ``scikit-package``
 
     .. code-block:: bash
 
-        $ package create public
+        package create public
 
 #. Answer the following questions:
 
@@ -121,7 +121,7 @@ Let's create a news item for the changes made in this PR.
 
     .. code-block:: bash
 
-        $ git pull origin skpkg-public
+        git pull origin skpkg-public
 
 #. Make a copy of ``news/TEMPLATE.rst`` and rename to ``news/<branch-name>.rst``.
 
@@ -143,9 +143,9 @@ Let's create a news item for the changes made in this PR.
 
     .. code-block:: bash
 
-        $ git add news/skpkg-public.rst
-        $ git commit -m "chore: Add news item for skpkg-public"
-        $ git push origin skpkg-public
+        git add news/skpkg-public.rst
+        git commit -m "chore: Add news item for skpkg-public"
+        git push origin skpkg-public
 
 Create a pull request
 ^^^^^^^^^^^^^^^^^^^^^
@@ -168,7 +168,7 @@ Create a pull request
 
         .. code-block:: bash
 
-         $ git pull origin skpkg-public
+         git pull origin skpkg-public
 
         If you have more problems, please read the FAQ section on :ref:`faq-pre-commit-error`.
 

--- a/news/rm-dollar-sign.rst
+++ b/news/rm-dollar-sign.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Remove ``$`` from codeblock in documentation.
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
closes #529 

This might give us some merge conflicts between this and the other PR: https://github.com/scikit-package/scikit-package/pull/526 but this should be nbd since its a small fix. 

edit: I added back the `$` for migration docs. This might help with the merge conflict but still might get some issues still.