### PR TITLE
chore: fix minor typo in `package create conda-forge` doc

### DIFF
--- a/doc/source/release-guides/conda-forge.rst
+++ b/doc/source/release-guides/conda-forge.rst
@@ -177,7 +177,7 @@ First, copy the ``SHA256`` value from `pypi.org <http://pypi.org>`_:
 
 .. seealso::
 
-    For your next release, you can automate Steps 1 through 12 by running ``package update feedstock`` in your command line. Read the section below :ref:`conda-forge-pr-automate`.
+    For your next release, you can automate Steps 1 through 12 by running ``package update conda-forge`` in your command line. Read the section below :ref:`conda-forge-pr-automate`.
 
 .. _conda-forge-pr-automate:
 
@@ -210,7 +210,7 @@ Yes! We provide ``package update conda-forge`` to streamline the conda-forge rel
 
 #. Save ``~/.skpkgrc``.
 
-#. Type ``package update feedstock``.
+#. Type ``package update conda-forge``.
 
 #. Enter the number corresponding to the package. It will create a PR from ``origin/<latest-version>`` to ``upstream/main``.
 

--- a/news/fix-typo.rst
+++ b/news/fix-typo.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: fix typo
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Just a quick typo caught by @ycexiao in https://github.com/scikit-package/scikit-package/pull/541