### PR TITLE
feat: allow user to reuse prompt values through project-wise config file `.skpkgrc`

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -14,5 +14,6 @@
   "minimum_supported_python_version": "3.11",
   "maximum_supported_python_version": "3.13",
   "project_needs_c_code_compiled": ["No", "Yes"],
-  "project_has_gui_tests": ["No", "Yes"]
+  "project_has_gui_tests": ["No", "Yes"],
+  "_copy_without_render": ["*.html", "*.js", ".github/*"]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -14,6 +14,5 @@
   "minimum_supported_python_version": "3.11",
   "maximum_supported_python_version": "3.13",
   "project_needs_c_code_compiled": ["No", "Yes"],
-  "project_has_gui_tests": ["No", "Yes"],
-  "_copy_without_render": ["*.html", "*.js", ".github/*"]
+  "project_has_gui_tests": ["No", "Yes"]
 }

--- a/news/proj-config.rst
+++ b/news/proj-config.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* allow user to reuse the prompt values through project-wise config file `.skpkgrc`.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/scikit_package/utils/cookie.py
+++ b/src/scikit_package/utils/cookie.py
@@ -5,9 +5,9 @@ from pathlib import Path
 
 SKPKG_USER_CONFIG_FILE = "~/.skpkgrc"
 try:
-    USER_CONFIG_FILE = os.environ["SKPKG_CONFIG_FILE"]
+    SKPKG_USER_CONFIG_FILE = os.environ["SKPKG_CONFIG_FILE"]
 except KeyError:
-    USER_CONFIG_FILE = SKPKG_USER_CONFIG_FILE
+    SKPKG_USER_CONFIG_FILE = SKPKG_USER_CONFIG_FILE
 
 SKPKG_PROJ_CONFIG_FILE = ".skpkgrc"
 

--- a/src/scikit_package/utils/cookie.py
+++ b/src/scikit_package/utils/cookie.py
@@ -1,37 +1,61 @@
+import json
 import os
 import subprocess
 from pathlib import Path
 
-SKPKG_CONFIG_FILE = "~/.skpkgrc"
+SKPKG_USER_CONFIG_FILE = "~/.skpkgrc"
 try:
-    config_file = os.environ["SKPKG_CONFIG_FILE"]
+    USER_CONFIG_FILE = os.environ["SKPKG_CONFIG_FILE"]
 except KeyError:
-    config_file = SKPKG_CONFIG_FILE
-config_file = os.path.expandvars(config_file)
-config_file = Path(config_file).expanduser()
-exist_config = config_file.exists()
+    USER_CONFIG_FILE = SKPKG_USER_CONFIG_FILE
+
+SKPKG_PROJ_CONFIG_FILE = ".skpkgrc"
+
+user_config_file = os.path.expandvars(SKPKG_USER_CONFIG_FILE)
+user_config_path = Path(user_config_file).expanduser()
+exist_user_config = user_config_path.exists()
+
+proj_config_file = SKPKG_PROJ_CONFIG_FILE
+proj_config_path = Path(SKPKG_PROJ_CONFIG_FILE)
+exist_proj_config = proj_config_path.exists()
+
+
+def read_skpkg_config(config_file):
+    config_path = Path(config_file).expanduser()
+    if not config_path.exists():
+        raise FileNotFoundError(
+            "scikit-packag configuration file ~/.skpkgrc is not found. "
+            "Please try again after running 'touch ~/.skpkgrc'."
+        )
+    with config_path.open() as f:
+        return json.load(f)
+
+
+def get_extra_context():
+    proj_config_dict = read_skpkg_config(proj_config_file)
+    overwrite_context = [
+        key + "=" + value
+        for key, value in proj_config_dict.items()
+        if not (value.startswith("[") and value.endswith("]"))
+    ]
+    return overwrite_context
 
 
 def run(repo_url):
+    run_cmd = ["cookiecutter", repo_url]
+
+    if exist_proj_config:
+        extra_context = get_extra_context()
+        run_cmd.extend(extra_context)
+
+    if exist_user_config:
+        run_cmd.extend(["--config-file", str(user_config_path)])
+
     try:
-        if exist_config:
-            subprocess.run(
-                [
-                    "cookiecutter",
-                    repo_url,
-                    "--config-file",
-                    config_file,
-                ],
-                check=True,
-            )
-        else:
-            subprocess.run(
-                [
-                    "cookiecutter",
-                    repo_url,
-                ],
-                check=True,
-            )
+        subprocess.run(
+            run_cmd,
+            check=True,
+        )
 
     except subprocess.CalledProcessError as e:
         print(f"Failed to run scikit-package for the following reason: {e}")

--- a/{{ cookiecutter.github_repo_name }}/.skpkgrc
+++ b/{{ cookiecutter.github_repo_name }}/.skpkgrc
@@ -14,6 +14,5 @@
   "minimum_supported_python_version": "{{ cookiecutter.minimum_supported_python_version }}",
   "maximum_supported_python_version": "{{ cookiecutter.maximum_supported_python_version }}",
   "project_needs_c_code_compiled": "{{ cookiecutter.project_needs_c_code_compiled }}",
-  "project_has_gui_tests": "{{ cookiecutter.project_has_gui_tests }}",
-  "_copy_without_render": "{{ cookiecutter._copy_without_render }}"
+  "project_has_gui_tests": "{{ cookiecutter.project_has_gui_tests }}"
 }

--- a/{{ cookiecutter.github_repo_name }}/.skpkgrc
+++ b/{{ cookiecutter.github_repo_name }}/.skpkgrc
@@ -1,0 +1,19 @@
+{
+  "maintainer_name": "{{ cookiecutter.maintainer_name }}",
+  "maintainer_email": "{{ cookiecutter.maintainer_email }}",
+  "maintainer_github_username": "{{ cookiecutter.maintainer_github_username }}",
+  "contributors": "{{ cookiecutter.contributors }}",
+  "license_holders": "{{ cookiecutter.license_holders }}",
+  "project_name": "{{ cookiecutter.project_name }}",
+  "github_username_or_orgname": "{{ cookiecutter.github_username_or_orgname }}",
+  "github_repo_name": "{{ cookiecutter.github_repo_name }}",
+  "conda_pypi_package_dist_name": "{{ cookiecutter.conda_pypi_package_dist_name }}",
+  "package_dir_name": "{{ cookiecutter.package_dir_name }}",
+  "project_short_description": "{{ cookiecutter.project_short_description }}",
+  "project_keywords": "{{ cookiecutter.project_keywords }}",
+  "minimum_supported_python_version": "{{ cookiecutter.minimum_supported_python_version }}",
+  "maximum_supported_python_version": "{{ cookiecutter.maximum_supported_python_version }}",
+  "project_needs_c_code_compiled": "{{ cookiecutter.project_needs_c_code_compiled }}",
+  "project_has_gui_tests": "{{ cookiecutter.project_has_gui_tests }}",
+  "_copy_without_render": "{{ cookiecutter._copy_without_render }}"
+}


### PR DESCRIPTION
### What problem does this PR address?
Closes #469 

Allow user to reuse their previous prompt values when recutting the package.

### What should the reviewers do?
Please check the inputs and outputs:

(1) First time `package create public`
![image](https://github.com/user-attachments/assets/326926c0-3307-4bf6-bb6f-205e9fe41d26)

(2) recut `diffpy.my-package`
![image](https://github.com/user-attachments/assets/20a854d5-b0b7-43d8-8da4-cb522b1719b0)

Also, the implementation code is stacked up at `cookie.py`, I think we can create a `config.py` and rewrite functions in `io.py` to obtain a better structure. @bobleesj, do we want to create another issue for this, or refactor the code in this PR?