### PR TITLE
Use pytest-mocker to override paths instead of manually overriding the paths for package add news function.

### DIFF
--- a/news/mock-add-news.rst
+++ b/news/mock-add-news.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Use pytest-mocker to override paths instead of manually overrding the paths for package add news function.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
@sbillinge since we've added `pytest-mocker`, maybe it's a good practice to utilize mocker?

Please see my in-line comments 