### PR TITLE
feat: add `package create <subcommand> --update` to clean up example files after creating the package

### DIFF
--- a/news/add-argument-update.rst
+++ b/news/add-argument-update.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add ``--update`` argument to ``package create <subcommand>`` to clean up example files after creating the package.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/scikit_package/app.py
+++ b/src/scikit_package/app.py
@@ -48,6 +48,13 @@ def setup_subparsers(parser):
         ("manuscript", "Create Overleaf LaTeX template of Billinge group."),
     ]
     _add_subcommands(subparsers_create, create_commands, create.package)
+    for _, subparser in subparsers_create.choices.items():
+        subparser.add_argument(
+            "-u",
+            "--update",
+            action="store_true",
+            help="Create the package in the update mode.",
+        )
     # "add" subparser
     parser_add = parser.add_parser(
         "add", help="Add a new file like a news item"

--- a/src/scikit_package/cli/create.py
+++ b/src/scikit_package/cli/create.py
@@ -1,6 +1,68 @@
+import json
+import shutil
+from pathlib import Path
+
+from jinja2 import Template
+
 from scikit_package.utils import cookie
 
 SKPKG_GITHUB_URL = "https://github.com/scikit-package/scikit-package"
+
+
+def cleanup_examples(project_dir, subcmd, config_dict):
+    files_or_dirs_to_be_removed_dict = {
+        "workspace": [
+            "proj-one",
+            "shared_functions.py",
+            "tests/test_shared_functions.py",
+        ],
+        "system": [
+            r"src/{{ package_dir_name }}/functions.py",
+            "tests/test_functions.py",
+        ],
+        "public": [
+            (r"docs/source/api/{{ package_dir_name }}" ".example_package.rst"),
+            "docs/source/getting-started.rst",
+            r"src/{{ package_dir_name }}/functions.py",
+            "tests/test_functions.py",
+            "docs/source/img/scikit-package-logo-text.png",
+            "docs/source/snippets/example-table.rst",
+        ],
+    }
+    files_or_dirs_to_be_removed = files_or_dirs_to_be_removed_dict[subcmd]
+    for filename in files_or_dirs_to_be_removed:
+        filename = Template(filename).render(**config_dict)
+        if "src" in filename.split("/")[0]:
+            parents = filename.split("/")[:-1]
+            name = filename.split("/")[-1]
+            parents = [parent.replace(".", "/") for parent in parents]
+            filename = "/".join([*parents, name])
+        file_path = project_dir / filename
+        if file_path.exists():
+            if file_path.is_file():
+                file_path.unlink()
+            else:
+                shutil.rmtree(file_path)
+        else:
+            print(
+                f"Unable to find {str(file_path)} to remove. "
+                "Cleanup process will continue. Please leave an issue "
+                "on GitHub."
+            )
+
+    files_to_be_added_dict = {
+        "workspace": [],
+        "system": [],
+        "public": [
+            "docs/source/img/.placeholder",
+            "docs/source/snippets/.placeholder",
+        ],
+    }
+    files_to_be_added = files_to_be_added_dict[subcmd]
+    for filename in files_to_be_added:
+        file_path = project_dir / filename
+        if not file_path.exists():
+            file_path.touch()
 
 
 def package(args):
@@ -9,6 +71,7 @@ def package(args):
     By default, checkout the latest release tag from the relevant GitHub
     repository.
     """
+    items_before_run = [f for f in Path().cwd().iterdir()]
     subcmd = args.subcommand
     if subcmd == "workspace":
         cookie.run(f"{SKPKG_GITHUB_URL}-workspace")
@@ -20,3 +83,30 @@ def package(args):
         cookie.run(f"{SKPKG_GITHUB_URL}-conda-forge")
     elif subcmd == "manuscript":
         cookie.run(f"{SKPKG_GITHUB_URL}-manuscript")
+    items_after_run = [f for f in Path().cwd().iterdir()]
+    if args.update:
+        print("Create the package in the update mode.")
+        generated_dirs = list(set(items_after_run) - set(items_before_run))
+        if len(generated_dirs) == 1:
+            project_dir = generated_dirs[0]
+        else:
+            print(
+                "Reverting to the normal mode "
+                "because scikit-package was unable to identify the generated "
+                "package. "
+                "Please leave an issue on GitHub."
+            )
+            return
+        created_proj_config_path = project_dir / "cookiecutter.json"
+        if created_proj_config_path.exists():
+            with open(created_proj_config_path, "r") as f:
+                config_dict = json.load(f)
+        else:
+            print(
+                "Reverting to the normal mode "
+                "because scikit-package was unable to find cookiecutter.json "
+                "in the generated package. "
+                "Please leave an issue on GitHub."
+            )
+            return
+        cleanup_examples(project_dir, subcmd, config_dict)


### PR DESCRIPTION
### What problem does this PR address?

Closes #527.

Clean up the example files after creating a package if `--update` or `-u` is passed to `package create <subcommand>`.

### What should the reviewer(s) do?

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->
Please check the implementation and output.

#### Implementation
To clean up the example files, `scikit-package` needs to find the generated package and to interpret variables like ` {{ cookiecutter.project_dir_name }} `

The generated package is found by comparing the directory before and after the `package create <subcommand>`.

The values for ` {{cookiecutter.project_dir_name}} ` are read from `cookiecutter.json` in the generated package.

#### Inputs/Outputs
<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->
(1)

Input: `package create workspace -u`
Output:
![image](https://github.com/user-attachments/assets/148b671f-4e8f-47f2-b893-029b19041e9b)

`tree workspace-folder`
```
workspace-folder
├── cookiecutter.json
├── pyproject.toml
├── README.md
├── requirements.txt
└── tests
    └── __init__.py
```
`project-one`, `shared_functions.py`, and `test_functions.py` are removed.

(2)
Input: `package create system -u`
Output:
![image](https://github.com/user-attachments/assets/bf3ec3e7-6171-44eb-80f0-7a9289169493)

`tree my-package`
```
my-package
├── cookiecutter.json
├── LICENSE.rst
├── pyproject.toml
├── README.md
├── requirements
│   ├── conda.txt
│   ├── pip.txt
│   └── test.txt
├── src
│   └── my_package
│       └── __init__.py
└── tests
```
`function.py` and `test_function.py` are removed.

(3)
Input: `package create public -u`
Output:
![image](https://github.com/user-attachments/assets/45abd669-4cc5-40c6-8603-b280d3a7b9e6)

`tree diffpy.my-package`. Some files are not shown here for simplicity.
```
diffpy.my-project
├── cookiecutter.json
├── docs
│   └── source
│       ├── conf.py
│       ├── img
│       │   └── .placeholder
│       ├── snippets
│       │   └── .placeholder
│       └── _static
│           └── .placeholder
├── src
│   └── diffpy
│       ├── __init__.py
│       └── my_project
│           ├── __init__.py
│           └── version.py
└── tests
    ├── conftest.py
    └── test_version.py
```
`doc/source/<package-name>.example_package.rst`, `doc/source/getting-started.rst`, `functions.py`, `test_functions.py`, `img/scikit-package-logo-text.png`, and `snippet/example-table.rst` are removed. Two `.placeholder`s are added.