### PR TITLE
docs: add documentation for `package create manuscript`

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -145,6 +145,7 @@ The Billinge Group's ``scikit-package`` has been modified from the NSLS-II scien
    tutorials/tutorial-level-5
    tutorials/tutorial-level-4-to-5
    tutorials/tutorial-level-5-migration
+   tutorials/tutorial-scikit-package-manuscript
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -145,7 +145,7 @@ The Billinge Group's ``scikit-package`` has been modified from the NSLS-II scien
    tutorials/tutorial-level-5
    tutorials/tutorial-level-4-to-5
    tutorials/tutorial-level-5-migration
-   tutorials/tutorial-scikit-package-manuscript
+   tutorials/tutorial-manuscript
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/snippets/user-input-manuscript.rst
+++ b/docs/source/snippets/user-input-manuscript.rst
@@ -10,6 +10,6 @@
       * - journal_template
         - Specifies which journal template to use to create the manuscript.
 	  The default value is ``[1]``, which corresponds to the ``article`` template.
-      * - latex_headers_repo_url
+      * - latex_latex_repo_url
         - The URL to the GitHub repository where the LaTeX files are located. Files with the specified names will be parsed, and the other files will be copied directly into the manuscript folder.
           e.g., ``https://github.com/scikit-package/default-latex-headers.git``

--- a/docs/source/snippets/user-input-manuscript.rst
+++ b/docs/source/snippets/user-input-manuscript.rst
@@ -1,0 +1,15 @@
+  .. list-table::
+      :header-rows: 1
+      :widths: 25 75
+
+      * - Prompt
+        - Description and example
+      * - project_name
+        - The name displayed in the ``README.rst``.
+          Use ``name-with-hyphens`` e.g., ``my-manuscript``.
+      * - journal_template
+        - Specifies which journal template to use to create the manuscript.
+	  The default value is ``[1]``, which corresponds to the ``article`` template.
+      * - latex_headers_repo_url
+        - The URL to the GitHub repository where the LaTeX files are located. Files with the specified names will be parsed, and the other files will be copied directly into the manuscript folder.
+          e.g., ``https://github.com/scikit-package/default-latex-headers.git``

--- a/docs/source/snippets/user-input-manuscript.rst
+++ b/docs/source/snippets/user-input-manuscript.rst
@@ -10,6 +10,6 @@
       * - journal_template
         - Specifies which journal template to use to create the manuscript.
 	  The default value is ``[1]``, which corresponds to the ``article`` template.
-      * - latex_latex_repo_url
+      * - user_latex_repo_url
         - The URL to the GitHub repository where the LaTeX files are located. Files with the specified names will be parsed, and the other files will be copied directly into the manuscript folder.
           e.g., ``https://github.com/scikit-package/default-latex-headers.git``

--- a/docs/source/tutorials/tutorial-level-4.rst
+++ b/docs/source/tutorials/tutorial-level-4.rst
@@ -35,6 +35,8 @@ For Level 4, we assume you have prior experience in developing scientific code i
 Step 1. Create a new package with ``scikit-package``
 ----------------------------------------------------
 
+.. _create-new-github-repo:
+
 Create a new GitHub repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/tutorials/tutorial-manuscript.rst
+++ b/docs/source/tutorials/tutorial-manuscript.rst
@@ -60,7 +60,7 @@ Create a manuscript folder with minimum setup.
 (Recommended) Customize the your LaTeX repositories
 ---------------------------------------------------
 
-The flexibility of ``scikit-package-manuscript`` is mainly attributed to the ability to customize LaTeX repositories for different manuscripts. The following steps will help you create a LaTeX repository to be used by ``package create manuscript``.
+The flexibility of using ``package create manuscript`` to create a manuscript folder is the ability to customize LaTeX repositories for different manuscripts. The following steps will help you create a LaTeX repository to be used by ``package create manuscript``.
 
 Example
 ^^^^^^^
@@ -75,15 +75,6 @@ Example
 
         cd ~
 	git clone <copied-my-latex-repo-example-url>
-
-#. Create the LaTeX files inside the ``~/my-latex-repo-example`` folder. These are the files that will be copied directly into the manuscript folder later.
-
-   .. code-block:: bash
-
-	cd ~/my-latex-repo-example
-	touch my-latex-file.tex
-	touch my-bib-file.bib
-	touch my-other-file.txt
 
 #. Create ``usepackages.txt`` and ``newcommands.txt`` inside the ``~/my-latex-repo-example`` directory.
 
@@ -110,6 +101,17 @@ Example
 	\newcommand{\command_3}[1]{\mathcal{#1}}
 	...
 
+
+#. You can also add any additional files inside the ``~/my-latex-repo-example`` folder. These are the files that will be copied directly into the manuscript folder. e.g.
+
+   .. code-block:: bash
+
+	cd ~/my-latex-repo-example
+	touch my-class-file.cls
+	touch my-style-file.sty
+	touch my-bib-file.bib
+
+
 #. Commit the change and sync the ``my-latex-repo-example`` repository in GitHub.
 
    .. code-block:: bash
@@ -128,7 +130,7 @@ Example
 
 A manuscript folder will be created in the ``~/my-manuscripts``. Files from the ``my-latex-repo-example`` GitHub repo will be copied into the manuscript folder. Packages and commands in ``usepackages.txt`` and ``newcommands.txt`` will be inserted after ``\documentclass`` in the main LaTeX file (``manuscript.tex`` by default) in the manuscript folder. The names of all ``.bib``  will be added to the ``\bibliography`` entry in the main LaTeX file.
 
-In this example, we used a GitHub repository named ``my-latex-repo-example`` to store the LaTeX files. The repository is maintained locally in ``~/my-latex-repo-example`` and five files ``my-latex-file.tex``, ``my-bib-file.bib``, ``my-other-file.txt``, ``usepackages.txt`` and ``newcommands.txt`` are created inside ``my-latex-repo-example``. The name for the repository and its local location can be chosen freely. You can also add, remove, or modify any files in that repository.
+In this example, we used a GitHub repository named ``my-latex-repo-example`` to store the LaTeX files. The repository is maintained locally in ``~/my-latex-repo-example`` and five files ``my-class-file.cls``, ``my-style-file.sty``, ``my-bib-file.bib``, ``usepackages.txt`` and ``newcommands.txt`` are created inside ``my-latex-repo-example``. The name for the repository and its local location can be chosen freely. You can also add, remove, or modify any files in that repository.
 
 Want a new manuscript template?
 ----------------------------------------------------------------------

--- a/docs/source/tutorials/tutorial-manuscript.rst
+++ b/docs/source/tutorials/tutorial-manuscript.rst
@@ -78,7 +78,7 @@ Example
 
 #. Create ``usepackages.txt`` and ``newcommands.txt`` inside the ``~/my-latex-repo-example`` directory.
 
-    ``usepackages.txt`` is used to add commands like ``\usepackage{graphicx}`` into the main LaTeX file. ``newcommands.txt`` is used to add commands like ``\newcommand{\a_command}[1]{\mathrm{#1}}`` into the main LaTeX file. The main LaTeX file is ``manuscript.tex`` in the manuscript folder by default.
+    ``usepackages.txt`` is used to import packages using ``\usepackage{graphicx}`` into the main LaTeX file. ``newcommands.txt`` is used to add commands like ``\newcommand{\a_command}[1]{\mathrm{#1}}`` into the main LaTeX file. The main LaTeX file is ``manuscript.tex`` in the manuscript folder by default.
 
    .. note::
       No LaTeX syntax check is executed during ``package create manuscript``. The content in ``usepackages.txt`` will be inserted after ``\documentclass`` and the content in ``newcommands.txt`` will be inserted after all ``\usepackage`` commands.

--- a/docs/source/tutorials/tutorial-manuscript.rst
+++ b/docs/source/tutorials/tutorial-manuscript.rst
@@ -22,7 +22,6 @@ To proceed with the following steps, we assume that you
 #. know how to use ``conda`` to create an environment and install ``scikit-package`` in the environment. Please see :ref:`conda-env-setup-simple` for more information.
 #. (Optional) know how to manage repositories on GitHub. Please see the GitHub tutorial `GitHub Hello World <https://docs.github.com/en/get-started/start-your-journey/hello-world>`_ for more information.
 
-
 .. _manuscript-run-the-command:
 
 Create a manuscript folder with minimum setup.
@@ -54,21 +53,17 @@ Create a manuscript folder with minimum setup.
 
         You may press the "Enter" key to accept the default values for the questions.
 
-
 3. Done! A manuscript folder named ``<project_name>`` is created inside ``<manuscript-folder-parent-folder>``.
-
 
 .. _manuscript-customize-latex-repo:
 
-(Recommended) How to customize the LaTeX repositories
------------------------------------------------------
+(Recommended) Customize the your LaTeX repositories
+---------------------------------------------------
 
 The flexibility of ``scikit-package-manuscript`` is mainly attributed to the ability to customize LaTeX repositories for different manuscripts. The following steps will help you create a LaTeX repository to be used by ``package create manuscript``.
 
 Example
 ^^^^^^^
-
-
 
 #. Create a GitHub repository. Please see :ref:`create-new-github-repo` for more information. As an example, set ``Repository name`` to be ``my-latex-repo-example``, choose the visibility to be ``public``, and select ``None`` for ``.gitignore`` and ``license``. You will be directed to the ``my-latex-repo-example`` page in GitHub after it is created.
 
@@ -97,7 +92,6 @@ Example
    .. note::
       No LaTeX syntax check is executed during ``package create manuscript``. The content in ``usepackages.txt`` will be inserted after ``\documentclass`` and the content in ``newcommands.txt`` will be inserted after all ``\usepackage`` commands.
 
-
    Example of ``usepackages.txt``
 
    .. code-block:: text
@@ -116,7 +110,6 @@ Example
 	\newcommand{\command_3}[1]{\mathcal{#1}}
 	...
 
-
 #. Commit the change and sync the ``my-latex-repo-example`` repository in GitHub.
 
    .. code-block:: bash
@@ -133,13 +126,11 @@ Example
 	cd ~/my-manuscripts
 	package create manuscript
 
-
 A manuscript folder will be created in the ``~/my-manuscripts``. Files from the ``my-latex-repo-example`` GitHub repo will be copied into the manuscript folder. Packages and commands in ``usepackages.txt`` and ``newcommands.txt`` will be inserted after ``\documentclass`` in the main LaTeX file (``manuscript.tex`` by default) in the manuscript folder. The names of all ``.bib``  will be added to the ``\bibliography`` entry in the main LaTeX file.
 
 In this example, we used a GitHub repository named ``my-latex-repo-example`` to store the LaTeX files. The repository is maintained locally in ``~/my-latex-repo-example`` and five files ``my-latex-file.tex``, ``my-bib-file.bib``, ``my-other-file.txt``, ``usepackages.txt`` and ``newcommands.txt`` are created inside ``my-latex-repo-example``. The name for the repository and its local location can be chosen freely. You can also add, remove, or modify any files in that repository.
 
-
 Want a new manuscript template?
 ----------------------------------------------------------------------
 
-Feel free to contribute it! You are welcom to create issues and PRs in `scikit-package-manuscript <https://github.com/scikit-package/scikit-package-manuscript>`_.
+Feel free to contribute it! You are welcome to create issues and PRs in `scikit-package-manuscript <https://github.com/scikit-package/scikit-package-manuscript>`_.

--- a/docs/source/tutorials/tutorial-manuscript.rst
+++ b/docs/source/tutorials/tutorial-manuscript.rst
@@ -1,31 +1,18 @@
 .. _scikit-package-manuscript-tutorials:
 
-Create your manuscript with ``scikit-package-manuscript``
-=========================================================
+Create a configured LaTeX manuscript folder with ``scikit-package``
+===================================================================
 
 Overview
 --------
 
-This is a tutorial for using ``scikit-package-manuscript`` template, which provides the command
+This is a tutorial for using ``scikit-package`` to create a configured manuscript folder by running the command
 
-.. code-block:: bash
+   .. code-block:: bash
 
 	package create manuscript
 
-in ``scikit-package`` to create a manuscript directory with a customized LaTeX repository.
-
-The tutorial is divided into two steps.
-
-- You will learn how to create an environment for ``scikit-package`` in :ref:`manuscript-create-the-environment`.
-- You will try the command ``package create manuscript`` and learn the prompt interface in :ref:`manuscript-run-the-command`.
-
-We strongly recommend that you read through :ref:`manuscript-customize-latex-repo` to unleash the full potential of ``scikit-package-mansucript``.
-
-
-How does ``scikit-package-manuscript`` benefit the manuscript writing process?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-``scikit-package-manuscript`` provides a systematic way to organize your these LaTeX snippets and simplifies finding and copying the reusable LaTeX snippets into choosing from pre-defined journal template and GitHub repository.
+We strongly recommend that you read through :ref:`manuscript-customize-latex-repo` to unleash the full potential of creating a manuscript folder with ``scikit-package``.
 
 Prerequisites
 ^^^^^^^^^^^^^^
@@ -33,43 +20,27 @@ Prerequisites
 To proceed with the following steps, we assume that you
 
 #. know how to use ``conda`` to create an environment and install ``scikit-package`` in the environment. Please see :ref:`conda-env-setup-simple` for more information.
-#. know how to manage repositories on GitHub. Please see the GitHub tutorial `GitHub Hello World <https://docs.github.com/en/get-started/start-your-journey/hello-world>`_ for more information.
-
-
-.. _manuscript-create-the-environment:
-
-Step 1. Create an environment and install ``scikit-package``
-------------------------------------------------------------
-
-#. Make sure ``conda`` is installed. Please see :ref:`conda-env-setup-simple` for more information.
-
-   .. code-block:: bash
-
-	conda --version
-
-#. Create a new environment and activate it.
-
-   .. code-block:: bash
-
-	conda create -n skpkg-manuscript
-	conda activate skpkg-manuscript
-
-
-#. Install ``scikit-package`` in the environment.
-
-   .. code-block:: bash
-
-	conda install scikit-package
+#. (Optional) know how to manage repositories on GitHub. Please see the GitHub tutorial `GitHub Hello World <https://docs.github.com/en/get-started/start-your-journey/hello-world>`_ for more information.
 
 
 .. _manuscript-run-the-command:
 
-Step 2. Run ``package create manuscript`` without customization
+Create a manuscript folder with minimum setup.
 ---------------------------------------------------------------
+#. Create a ``conda`` environment with ``scikit-package`` installed and activate the environment. Please see :ref:`conda-env-setup-simple` for more information.
 
-After Step 1, ``scikit-package-manuscript`` is enabled with a minimal setup.
+   .. code-block:: bash
 
-1. Run ``scikit-package-manuscript``.
+	conda create -n <project-name>-env scikit-package
+	conda activate <project-name>-env
+
+#. Go to the path where the manuscript folder will be created.
+
+   .. code-block:: bash
+
+	cd <manuscript-folder-parent-folder>
+
+#. Run the command.
 
    .. code-block:: bash
 
@@ -84,7 +55,7 @@ After Step 1, ``scikit-package-manuscript`` is enabled with a minimal setup.
         You may press the "Enter" key to accept the default values for the questions.
 
 
-3. Done! A manuscript folder named ``project_name`` is created in your working directory.
+3. Done! A manuscript folder named ``<project_name>`` is created inside ``<manuscript-folder-parent-folder>``.
 
 
 .. _manuscript-customize-latex-repo:
@@ -92,39 +63,39 @@ After Step 1, ``scikit-package-manuscript`` is enabled with a minimal setup.
 (Recommended) How to customize the LaTeX repositories
 -----------------------------------------------------
 
-The flexibility of ``scikit-package-manuscript`` is mainly attributed to that LaTeX repositories can be customized for different manuscripts. The following steps will help you create a LaTeX repository to be used by ``package create manuscript``
+The flexibility of ``scikit-package-manuscript`` is mainly attributed to the ability to customize LaTeX repositories for different manuscripts. The following steps will help you create a LaTeX repository to be used by ``package create manuscript``.
 
-#. Create a GitHub repository and copy the repository URL. Please see :ref:`create-new-github-repo` for more information.
+Example
+^^^^^^^
 
-#. Create a directory ``<latex-repo-dir>`` to store the LaTeX files and associate the directory with the GitHub repository.
 
-   .. code-block:: bash
 
-	mkdir <latex-repo-dir>
-	cd <latex-repo-dir>
-	git init
-	git remote add origin <coppied-repository-URL>
+#. Create a GitHub repository. Please see :ref:`create-new-github-repo` for more information. As an example, set ``Repository name`` to be ``my-latex-repo-example``, choose the visibility to be ``public``, and select ``None`` for ``.gitignore`` and ``license``. You will be directed to the ``my-latex-repo-example`` page in GitHub after it is created.
 
-#. Copy the files that you want to include in the manuscript folder into the ``<latex-repo-dir>`` directory. During ``package create manuscript``, these files will be copied into the manuscript folder without modifications.
+#. Find the ``Quick setup`` section in the ``my-latex-repo-example`` page, choose the ``HTTPS`` option and copy the URL in the section. The URL will be referred to as ``<copied-my-latex-repo-example-url>`` in the following steps.
 
-   e.g.
+#. Open the terminal and clone the ``my-latex-repo-example`` repository. After the command, a ``my-latex-repo-example`` folder will be created locally.
 
    .. code-block:: bash
 
-	cp my-class-file.cls <latex-repo-dir>/
-	cp my-style-file.bst <latex-repo-dir>/
-	cp my-bib-file-1.bib <latex-repo-dir>/
-	cp my-bib-file-2.bib <latex-repo-dir>/
-	cp my-latex-file.tex <latex-repo-dir>/
-	cp other-file.txt <latex-repo-dir>/
+        cd ~
+	git clone <copied-my-latex-repo-example-url>
 
+#. Create the LaTeX files inside the ``~/my-latex-repo-example`` folder. These are the files that will be copied directly into the manuscript folder later.
 
-#. Create ``usepackages.txt`` and ``newcommands.txt`` in the ``<latex-repo-dir>`` directory.
+   .. code-block:: bash
 
-   ``usepackages.txt`` is used to add commands like ``\usepackage{graphicx}`` into the main LaTeX file. ``newcommands.txt`` is used to add commands like ``\newcommand{\a_command}[1]{\mathrm{#1}}`` into the main LaTeX file. The main LaTeX file is ``manuscript.tex`` in the manuscript folder by default.
+	cd ~/my-latex-repo-example
+	touch my-latex-file.tex
+	touch my-bib-file.bib
+	touch my-other-file.txt
+
+#. Create ``usepackages.txt`` and ``newcommands.txt`` inside the ``~/my-latex-repo-example`` directory.
+
+    ``usepackages.txt`` is used to add commands like ``\usepackage{graphicx}`` into the main LaTeX file. ``newcommands.txt`` is used to add commands like ``\newcommand{\a_command}[1]{\mathrm{#1}}`` into the main LaTeX file. The main LaTeX file is ``manuscript.tex`` in the manuscript folder by default.
 
    .. note::
-      No LaTeX syntax check is executed during ``package create manuscript``. The content in ``usepackages.txt`` is what will be inserted after ``\documentclass`` and the content in ``newcommands.txt`` is what will be inserted after all ``\usepackage``.
+      No LaTeX syntax check is executed during ``package create manuscript``. The content in ``usepackages.txt`` will be inserted after ``\documentclass`` and the content in ``newcommands.txt`` will be inserted after all ``\usepackage`` commands.
 
 
    Example of ``usepackages.txt``
@@ -146,7 +117,7 @@ The flexibility of ``scikit-package-manuscript`` is mainly attributed to that La
 	...
 
 
-#. Commit the change and sync the repository with the one in GitHub.
+#. Commit the change and sync the ``my-latex-repo-example`` repository in GitHub.
 
    .. code-block:: bash
 
@@ -154,12 +125,21 @@ The flexibility of ``scikit-package-manuscript`` is mainly attributed to that La
 	git commit -m 'skpkg: initialize a LaTeX repository'
 	git push origin main
 
-#. Done! You can now run ``package create manuscript`` using this GitHub repository's URL as the input for ``latex_headers_repo_url`` to test it.
+#. Done! To test it, go to the path where a manuscript folder will be created and run ``package create manuscript`` with ``<copied-my-latex-example-url>`` as the input for ``<user_latex_repo_url>``.
 
-A manuscript folder will be created in the working directory. Files from the GitHub repository will be copied into the manuscript folder. Packages and commands in ``usepackages.txt`` and ``newcommands.txt`` will be inserted after ``\documentclass`` in the main LaTeX file (``manuscript.tex`` by default) in the manuscript folder. The names of all ``.bib``  will be added to the ``\bibliography`` entry in the main LaTeX file.
+   .. code-block:: bash
+
+	mkdir ~/my-manuscripts
+	cd ~/my-manuscripts
+	package create manuscript
 
 
-How to contribute
------------------
+A manuscript folder will be created in the ``~/my-manuscripts``. Files from the ``my-latex-repo-example`` GitHub repo will be copied into the manuscript folder. Packages and commands in ``usepackages.txt`` and ``newcommands.txt`` will be inserted after ``\documentclass`` in the main LaTeX file (``manuscript.tex`` by default) in the manuscript folder. The names of all ``.bib``  will be added to the ``\bibliography`` entry in the main LaTeX file.
 
-Please make an issue on `scikit-package-manuscript <https://github.com/scikit-package/scikit-package-manuscript>`_ if you have any new features.
+In this example, we used a GitHub repository named ``my-latex-repo-example`` to store the LaTeX files. The repository is maintained locally in ``~/my-latex-repo-example`` and five files ``my-latex-file.tex``, ``my-bib-file.bib``, ``my-other-file.txt``, ``usepackages.txt`` and ``newcommands.txt`` are created inside ``my-latex-repo-example``. The name for the repository and its local location can be chosen freely. You can also add, remove, or modify any files in that repository.
+
+
+Want a new manuscript template?
+----------------------------------------------------------------------
+
+Feel free to contribute it! You are welcom to create issues and PRs in `scikit-package-manuscript <https://github.com/scikit-package/scikit-package-manuscript>`_.

--- a/docs/source/tutorials/tutorial-manuscript.rst
+++ b/docs/source/tutorials/tutorial-manuscript.rst
@@ -6,13 +6,20 @@ Create your manuscript with ``scikit-package-manuscript``
 Overview
 --------
 
-This is a tutorial for using ``scikit-package-manuscript``. The following steps can help you to learn to use
+This is a tutorial for using ``scikit-package-manuscript`` template, which provides the command
 
 .. code-block:: bash
 
 	package create manuscript
 
-to create a manuscript directory with a customized LaTeX repository.
+in ``scikit-package`` to create a manuscript directory with a customized LaTeX repository.
+
+The tutorial is divided into two steps.
+
+- You will learn how to create an environment for ``scikit-package`` in :ref:`manuscript-create-the-environment`.
+- You will try the command ``package create manuscript`` and learn the prompt interface in :ref:`manuscript-run-the-command`.
+
+We strongly recommend that you read through :ref:`manuscript-customize-latex-repo` to unleash the full potential of ``scikit-package-mansucript``.
 
 
 How does ``scikit-package-manuscript`` benefit the manuscript writing process?
@@ -27,13 +34,6 @@ To proceed with the following steps, we assume that you
 
 #. know how to use ``conda`` to create an environment and install ``scikit-package`` in the environment. Please see :ref:`conda-env-setup-simple` for more information.
 #. know how to manage repositories on GitHub. Please see the GitHub tutorial `GitHub Hello World <https://docs.github.com/en/get-started/start-your-journey/hello-world>`_ for more information.
-
-
-Table of contents
-^^^^^^^^^^^^^^^^^
-
-1. :ref:`manuscript-create-the-environment`.
-2. :ref:`manuscript-run-the-command`.
 
 
 .. _manuscript-create-the-environment:
@@ -86,8 +86,6 @@ After Step 1, ``scikit-package-manuscript`` is enabled with a minimal setup.
 
 3. Done! A manuscript folder named ``project_name`` is created in your working directory.
 
-
-Now you can use ``scikit-package-manuscript`` to create your manuscript in a easy and efficient manner. We highly recommend you to read through :ref:`manuscript-customize-latex-repo` to release the full potential of ``scikit-package-manuscript``.
 
 .. _manuscript-customize-latex-repo:
 

--- a/docs/source/tutorials/tutorial-scikit-package-manuscript.rst
+++ b/docs/source/tutorials/tutorial-scikit-package-manuscript.rst
@@ -45,7 +45,7 @@ Table of contents
 Step 1. Create an environment and install ``scikit-package``
 ------------------------------------------------------------
 
-#. Make sure ``conda`` is installed.
+#. Make sure ``conda`` is installed. Please see :ref:`conda-env-setup-simple` for more information.
 
    .. code-block:: bash
 
@@ -119,7 +119,7 @@ Step 3. Customize the LaTeX repositories
 	cp my-style-file.bst <latex-repo-dir>/
 	cp my-bib-file-1.bib <latex-repo-dir>/
 	cp my-bib-file-2.bib <latex-repo-dir>/
-	cp another-latex-file.tex <latex-repo-dir>/
+	cp my-latex-file.tex <latex-repo-dir>/
 	cp other-file.txt <latex-repo-dir>/
 
 

--- a/docs/source/tutorials/tutorial-scikit-package-manuscript.rst
+++ b/docs/source/tutorials/tutorial-scikit-package-manuscript.rst
@@ -26,7 +26,7 @@ Prerequisites
 To proceed with the following steps, we assume that you
 
 #. know how to use ``conda`` to create an environment and install ``scikit-package`` in the environment. Please see :ref:`conda-env-setup-simple` for more information.
-#. know how to manage repositories on GitHub. Please see the GitHub tutorial `GitHub Hello Horld <https://docs.github.com/en/get-started/start-your-journey/hello-world>`_ for more information.
+#. know how to manage repositories on GitHub. Please see the GitHub tutorial `GitHub Hello World <https://docs.github.com/en/get-started/start-your-journey/hello-world>`_ for more information.
 
 
 Table of contents

--- a/docs/source/tutorials/tutorial-scikit-package-manuscript.rst
+++ b/docs/source/tutorials/tutorial-scikit-package-manuscript.rst
@@ -1,0 +1,169 @@
+.. _scikit-package-manuscript-tutorials:
+
+Creating your manuscript with ``scikit-package-manuscript``
+===========================================================
+
+Overview
+--------
+
+This is a tutorial for using ``scikit-package-manuscript``. The following steps can help you to learn to use
+
+.. code-block:: bash
+
+		package create manuscript
+
+to create a manuscript directory with a customized LaTeX repository.
+
+
+How does ``scikit-package-manuscript`` benefit the manuscript writing process?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A common way of managing reusable LaTeX files is to do it manually. For users who maintain a large amount of reusable LaTeX files, finding and copying the correct LaTeX snippets into the newly created manuscript can be a tiresome task, especially when different manuscripts need quite different LaTeX snippets and when users have to do it frequently.
+
+
+``scikit-package-manuscript`` is a template in the ``scikit-package`` project which provides a systematic way to organize your reusable LaTeX snippets and simplifies selecting and copying the reusable LaTeX snippets into choosing from pre-defined ``journal_template`` and ``latex_headers_repo_url`` options.
+
+
+Prerequisites
+^^^^^^^^^^^^^^
+To proceed with the following steps, we assume that you
+
+#. Know how to use ``conda`` to create an environment and install ``scikit-package`` in the environment. Please see :ref:`conda-env-setup-simple` for more information.
+#. Know how to manage repositories on GitHub. Please see the GitHub tutorial `GitHub hello world <https://docs.github.com/en/get-started/start-your-journey/hello-world>`_ for more information.
+
+
+Table of contents
+^^^^^^^^^^^^^^^^^
+
+1. :ref:`create-environment-with-scikit-package`
+2. :ref:`try-package-create-manuscript`
+3. :ref:`customize-latex-repo`
+
+
+.. _create-environment-with-scikit-package:
+
+Step 1. Create an environment and install ``scikit-package``
+------------------------------------------------------------
+
+#. Make sure ``conda`` is installed.
+
+   .. code-block:: bash
+
+	conda --version
+
+#. Create a new environment and activate it.
+
+   .. code-block:: bash
+
+	conda create -n skpkg-manuscript
+	conda activate skpkg-manuscript
+
+
+#. Install ``scikit-package`` in the environment.
+
+   .. code-block:: bash
+
+	conda install scikit-package
+
+
+.. _try-package-create-manuscript:
+
+Step 2. Try ``package create manuscript`` without customization
+---------------------------------------------------------------
+
+After Step 1, ``scikit-package-manuscript`` is enabled with a minimal setup.
+
+1. Invoke ``scikit-package-manuscript``
+
+   .. code-block:: bash
+
+	package create manuscript
+
+2. Answer the following questions
+
+    .. include:: ../snippets/user-input-manuscript.rst
+
+    .. note::
+
+        You may press the "Enter" key to accept the default values for the questions.
+
+
+3. Done! A manuscript folder named ``project_name`` is created in your working directory.
+
+You can use a different LaTeX repository URL as the input for ``latex_headers_repo_url`` during the process. The flexibility of ``scikit-package-manuscript`` is mainly attributed to that LaTeX repositories can be customized for different manuscripts.
+
+
+.. _customize-latex-repo:
+
+Step 3. Customize the LaTeX repositories
+-----------------------------------------
+
+#. Create a GitHub repository and copy the repository URL. Please see :ref:`create-new-github-repo` for more information.
+
+#. Create a directory ``<latex-repo-dir>`` to store the LaTeX files and associate the directory with the GitHub repository.
+
+   .. code-block:: bash
+
+	mkdir <latex-repo-dir>
+	cd <latex-repo-dir>
+	git init
+	git remote add origin <coppied-repository-URL>
+
+#. Copy the files that you want to include in the manuscript folder into the ``<latex-repo-dir>`` directory. During ``package create manuscript``, these files will be copied into the manuscript folder without modifications.
+
+   e.g.
+
+   .. code-block:: bash
+
+	cp my-class-file.cls <latex-repo-dir>/
+	cp my-style-file.bst <latex-repo-dir>/
+	cp my-bib-file-1.bib <latex-repo-dir>/
+	cp my-bib-file-2.bib <latex-repo-dir>/
+	cp another-latex-file.tex <latex-repo-dir>/
+	cp other-file.txt <latex-repo-dir>/
+
+
+#. Create ``usepackages.txt`` and ``newcommands.txt`` in the ``<latex-repo-dir>`` directory.
+
+   ``usepackages.txt`` is used to add commands like ``\usepackage{graphicx}`` into the main LaTeX file. ``newcommands.txt`` is used to add commands like ``\newcommand{\a_command}[1]{\mathrm{#1}}`` into the main LaTeX file. The main LaTeX file is ``manuscript.tex`` in the manuscript folder by default.
+
+   .. note::
+      No LaTeX syntax check is executed during ``package create manuscript``. The content in ``usepackages.txt`` is what will be inserted after ``\documentclass`` and the content in ``newcommands.txt`` is what will be inserted after all ``\usepackage``.
+
+
+   Example of ``usepackages.txt``
+
+   .. code-block:: text
+
+	\usepackage{mathtools}
+	\usepackage{amsmath}
+	\usepackage{mathtools}
+	...
+
+   Example of ``newcommands.txt``
+
+   .. code-block:: text
+
+	\newcommand{\command_1}[1]{\mathrm{#1}}
+	\newcommand{\command_2}[1]{\mathbb{#1}}
+	\newcommand{\command_3}[1]{\mathcal{#1}}
+	...
+
+
+#. Commit the change and sync the repository with the one in GitHub.
+
+   .. code-block:: bash
+
+	git add .
+	git commit -m '<your-commit-message>'
+	git push origin main
+
+#. Done! You can now run ``package create manuscript`` using this GitHub repository's URL as the input for ``latex_headers_repo_url`` to test it.
+
+   A manuscript folder will be created in the working directory. Files from the GitHub repository will be copied into the manuscript folder. Packages and commands in ``usepackages.txt`` and ``newcommands.txt`` will be inserted after ``\documentclass`` in the main LaTeX file (``manuscript.tex`` by default) in the manuscript folder. The names of all ``.bib``  will be added to the ``\bibliography`` entry in the main LaTeX file.
+
+
+How to contribute
+-----------------
+
+Please make an issue on `scikit-package-manuscript <https://github.com/scikit-package/scikit-package-manuscript>`_ if you have any new features.

--- a/docs/source/tutorials/tutorial-scikit-package-manuscript.rst
+++ b/docs/source/tutorials/tutorial-scikit-package-manuscript.rst
@@ -1,7 +1,7 @@
 .. _scikit-package-manuscript-tutorials:
 
-Creating your manuscript with ``scikit-package-manuscript``
-===========================================================
+Create your manuscript with ``scikit-package-manuscript``
+=========================================================
 
 Overview
 --------
@@ -10,7 +10,7 @@ This is a tutorial for using ``scikit-package-manuscript``. The following steps 
 
 .. code-block:: bash
 
-		package create manuscript
+	package create manuscript
 
 to create a manuscript directory with a customized LaTeX repository.
 
@@ -18,29 +18,25 @@ to create a manuscript directory with a customized LaTeX repository.
 How does ``scikit-package-manuscript`` benefit the manuscript writing process?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A common way of managing reusable LaTeX files is to do it manually. For users who maintain a large amount of reusable LaTeX files, finding and copying the correct LaTeX snippets into the newly created manuscript can be a tiresome task, especially when different manuscripts need quite different LaTeX snippets and when users have to do it frequently.
-
-
-``scikit-package-manuscript`` is a template in the ``scikit-package`` project which provides a systematic way to organize your reusable LaTeX snippets and simplifies selecting and copying the reusable LaTeX snippets into choosing from pre-defined ``journal_template`` and ``latex_headers_repo_url`` options.
-
+``scikit-package-manuscript`` provides a systematic way to organize your these LaTeX snippets and simplifies finding and copying the reusable LaTeX snippets into choosing from pre-defined journal template and GitHub repository.
 
 Prerequisites
 ^^^^^^^^^^^^^^
+
 To proceed with the following steps, we assume that you
 
-#. Know how to use ``conda`` to create an environment and install ``scikit-package`` in the environment. Please see :ref:`conda-env-setup-simple` for more information.
-#. Know how to manage repositories on GitHub. Please see the GitHub tutorial `GitHub hello world <https://docs.github.com/en/get-started/start-your-journey/hello-world>`_ for more information.
+#. know how to use ``conda`` to create an environment and install ``scikit-package`` in the environment. Please see :ref:`conda-env-setup-simple` for more information.
+#. know how to manage repositories on GitHub. Please see the GitHub tutorial `GitHub Hello Horld <https://docs.github.com/en/get-started/start-your-journey/hello-world>`_ for more information.
 
 
 Table of contents
 ^^^^^^^^^^^^^^^^^
 
-1. :ref:`create-environment-with-scikit-package`
-2. :ref:`try-package-create-manuscript`
-3. :ref:`customize-latex-repo`
+1. :ref:`manuscript-create-the-environment`.
+2. :ref:`manuscript-run-the-command`.
 
 
-.. _create-environment-with-scikit-package:
+.. _manuscript-create-the-environment:
 
 Step 1. Create an environment and install ``scikit-package``
 ------------------------------------------------------------
@@ -66,20 +62,20 @@ Step 1. Create an environment and install ``scikit-package``
 	conda install scikit-package
 
 
-.. _try-package-create-manuscript:
+.. _manuscript-run-the-command:
 
-Step 2. Try ``package create manuscript`` without customization
+Step 2. Run ``package create manuscript`` without customization
 ---------------------------------------------------------------
 
 After Step 1, ``scikit-package-manuscript`` is enabled with a minimal setup.
 
-1. Invoke ``scikit-package-manuscript``
+1. Run ``scikit-package-manuscript``.
 
    .. code-block:: bash
 
 	package create manuscript
 
-2. Answer the following questions
+2. Answer the following questions:
 
     .. include:: ../snippets/user-input-manuscript.rst
 
@@ -90,13 +86,15 @@ After Step 1, ``scikit-package-manuscript`` is enabled with a minimal setup.
 
 3. Done! A manuscript folder named ``project_name`` is created in your working directory.
 
-You can use a different LaTeX repository URL as the input for ``latex_headers_repo_url`` during the process. The flexibility of ``scikit-package-manuscript`` is mainly attributed to that LaTeX repositories can be customized for different manuscripts.
 
+Now you can use ``scikit-package-manuscript`` to create your manuscript in a easy and efficient manner. We highly recommend you to read through :ref:`manuscript-customize-latex-repo` to release the full potential of ``scikit-package-manuscript``.
 
-.. _customize-latex-repo:
+.. _manuscript-customize-latex-repo:
 
-Step 3. Customize the LaTeX repositories
------------------------------------------
+(Recommended) How to customize the LaTeX repositories
+-----------------------------------------------------
+
+The flexibility of ``scikit-package-manuscript`` is mainly attributed to that LaTeX repositories can be customized for different manuscripts. The following steps will help you create a LaTeX repository to be used by ``package create manuscript``
 
 #. Create a GitHub repository and copy the repository URL. Please see :ref:`create-new-github-repo` for more information.
 
@@ -155,12 +153,12 @@ Step 3. Customize the LaTeX repositories
    .. code-block:: bash
 
 	git add .
-	git commit -m '<your-commit-message>'
+	git commit -m 'skpkg: initialize a LaTeX repository'
 	git push origin main
 
 #. Done! You can now run ``package create manuscript`` using this GitHub repository's URL as the input for ``latex_headers_repo_url`` to test it.
 
-   A manuscript folder will be created in the working directory. Files from the GitHub repository will be copied into the manuscript folder. Packages and commands in ``usepackages.txt`` and ``newcommands.txt`` will be inserted after ``\documentclass`` in the main LaTeX file (``manuscript.tex`` by default) in the manuscript folder. The names of all ``.bib``  will be added to the ``\bibliography`` entry in the main LaTeX file.
+A manuscript folder will be created in the working directory. Files from the GitHub repository will be copied into the manuscript folder. Packages and commands in ``usepackages.txt`` and ``newcommands.txt`` will be inserted after ``\documentclass`` in the main LaTeX file (``manuscript.tex`` by default) in the manuscript folder. The names of all ``.bib``  will be added to the ``\bibliography`` entry in the main LaTeX file.
 
 
 How to contribute

--- a/news/skm-doc.rst
+++ b/news/skm-doc.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add tutorial for ``scikit-package-manuscript``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
# What problem does this PR address?
Closes #517 

Add a `package create manuscript`  section in the documentation.

# What should the reviewer(s) do?

Please check the rendered documentation.
<img width="1402" height="1175" alt="image" src="https://github.com/user-attachments/assets/61f5d569-e440-4cf5-ac0e-1e80d54ff4bc" />
