### PR TITLE
test: use `re.escape` when matching windows paths in `test_io.py`

### DIFF
--- a/news/fix-test-io.rst
+++ b/news/fix-test-io.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Use ``re.escape`` when matching windows paths in ``test_io.py``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from scikit_package.utils.io import copy_all_files
@@ -70,7 +72,7 @@ def test_copy_all_files_bad(user_filesystem):
     package_dir = user_filesystem / "package-dir"
     with pytest.raises(
         FileNotFoundError,
-        match=(
+        match=re.escape(
             "Unable to find the source directory: "
             f"{str(non_existing_source_dir)}."
         ),
@@ -82,7 +84,7 @@ def test_copy_all_files_bad(user_filesystem):
     assert empty_source_dir.exists() and (not any(empty_source_dir.iterdir()))
     with pytest.raises(
         FileNotFoundError,
-        match=(
+        match=re.escape(
             f"Source directory {str(empty_source_dir)} found "
             "but it contains no files."
         ),


### PR DESCRIPTION
### What problem does this PR address?

Address the CI falling mentioned in #590

The problem is with matching Windows path, which contains backslashes. `re.escape` can be used to solve this.

### What should the reviewer(s) do?

Please check the modifications.