### PR TITLE
chore: revert the change as `news` is added in the source list

### DIFF
--- a/news/revert-news.rst
+++ b/news/revert-news.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* use ``news`` from the repo in the tests since ``news`` is added in the source list.
+
+**Security:**
+
+* <news item>

--- a/tests/test_add_news.py
+++ b/tests/test_add_news.py
@@ -1,3 +1,5 @@
+import shutil
+from pathlib import Path
 from types import SimpleNamespace
 
 from scikit_package.cli.add import news_item
@@ -9,33 +11,10 @@ def _setup_news_test_env(tmp_path, mocker):
     test_news_dir = tmp_path / "news"
     test_news_dir.mkdir()
     # Locate the real TEMPLATE.rst file in the project root
+    project_root = Path(__file__).resolve().parents[1]
+    real_template_path = project_root / "news" / "TEMPLATE.rst"
     test_template_file = test_news_dir / "TEMPLATE.rst"
-    test_template_file.write_text(
-        """**Added:**
-
-* <news item>
-
-**Changed:**
-
-* <news item>
-
-**Deprecated:**
-
-* <news item>
-
-**Removed:**
-
-* <news item>
-
-**Fixed:**
-
-* <news item>
-
-**Security:**
-
-* <news item>
-"""
-    )
+    shutil.copy(real_template_path, test_template_file)
     # Mock the paths and the branch
     mocker.patch("scikit_package.cli.add.NEWS_DIR", str(test_news_dir))
     mocker.patch(


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->
Revert #608 since we decided to add `news` into the source list https://github.com/conda-forge/scikit-package-feedstock/pull/6/commits/fffbe2263fa7625939a0aeab3dc2e9583d07c145.

### What should the reviewer(s) do?

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->

<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->
