### PR TITLE
feat: support input multiple authors and maintainers

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,9 @@
 {
-  "maintainer_name": "Simon Billinge",
-  "maintainer_email": "sb2896@columbia.edu",
-  "maintainer_github_username": "sbillinge",
+  "author_names": "Simon Billinge, Sangjoon Bob Lee",
+  "author_emails": "sb2896@columbia.edu, sl5400@columbia.edu",
+  "maintainer_names": "{{ cookiecutter.author_names }}",
+  "maintainer_emails": "{{ cookiecutter.author_emails }}",
+  "maintainer_github_usernames": "sbillinge, bobleesj",
   "contributors": "Sangjoon Lee, Simon Billinge, Billinge Group members",
   "license_holders": "The Trustees of Columbia University in the City of New York",
   "project_name": "diffpy.my-project",
@@ -16,5 +18,6 @@
   "project_needs_c_code_compiled": ["No", "Yes"],
   "project_has_gui_tests": ["No", "Yes"],
   "_is_skpkg_update": "No",
-  "_copy_without_render": ["*.html", "*.js", ".github/*"]
+  "_copy_without_render": ["*.html", "*.js", ".github/*"],
+  "_extensions": ["hooks.local_extensions.people_contact_info_Extension"]
 }

--- a/hooks/local_extensions.py
+++ b/hooks/local_extensions.py
@@ -1,0 +1,65 @@
+from jinja2.ext import Extension
+
+
+class people_contact_info_Extension(Extension):
+    def __init__(self, environment):
+        super(people_contact_info_Extension, self).__init__(environment)
+        environment.filters["expand_to_dict_with_email"] = (
+            self.expand_to_dict_with_email
+        )
+        environment.filters["expand_to_str_with_email"] = (
+            self.expand_to_str_with_email
+        )
+        environment.filters["list_in_str"] = self.list_in_str
+
+    def expand_to_dict_with_email(self, names, emails):
+        """Expand names and emails to a list of dicts."""
+        names = names.split(",")
+        emails = emails.split(",")
+        if not len(names) == len(emails):
+            raise KeyError(
+                "The number of names and emails must be the same. "
+                f"Got {len(names)} names and {len(emails)} emails."
+            )
+        people_contact_info_Extension = ""
+        for n, e in zip(names, emails):
+            people_contact_info_Extension += (
+                f"  {{name='{n.strip()}', email='{e.strip()}'}},\n"
+            )
+        people_contact_info_Extension = (
+            "[\n" + people_contact_info_Extension + "]"
+        )
+        return people_contact_info_Extension
+
+    def expand_to_str_with_email(self, names, emails):
+        """Expand names with emails in parentheses."""
+        names = names.split(",")
+        emails = emails.split(",")
+        if not len(names) == len(emails):
+            raise KeyError(
+                "The number of names and emails must be the same. "
+                f"Got {len(names)} names and {len(emails)} emails."
+            )
+        people_contact_info_Extension = (
+            f"{names[0].strip()}({emails[0].strip()})"
+        )
+        for i in range(1, len(names)):
+            if i != len(names) - 1:
+                people_contact_info_Extension += (
+                    f", {names[i].strip()}({emails[i].strip()})"
+                )
+            else:
+                people_contact_info_Extension += (
+                    f", and {names[i].strip()}({emails[i].strip()})"
+                )
+
+        people_contact_info_Extension = people_contact_info_Extension
+        return people_contact_info_Extension
+
+    def list_in_str(self, items):
+        """Convert a list of items to a comma-separated string with
+        'and' before the last item."""
+        items = [item.strip() for item in items.split(",")]
+        if len(items) == 1:
+            return items[0]
+        return ", ".join(items[:-1]) + ", and " + items[-1]

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -202,7 +202,7 @@ def update_workflow():
 
     workflow_input = {
         "PROJECT": "{{ cookiecutter.project_name }}",
-        "MAINTAINER_GITHUB_USERNAME": "{{ cookiecutter.maintainer_github_username }}",
+        "MAINTAINER_GITHUB_USERNAME": "{{ cookiecutter.maintainer_github_usernames }}",
         "C_EXTENSION": str(
             "{{ cookiecutter.project_needs_c_code_compiled }}" == "Yes"
         ).lower(),

--- a/news/list-of-authors.rst
+++ b/news/list-of-authors.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Support setting multiple authors and maintainers.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,0 +1,108 @@
+import importlib
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment
+
+spec = importlib.util.spec_from_file_location(
+    "local_extensions",
+    Path(__file__).parents[1] / "hooks" / "local_extensions.py",
+)
+local_extensions = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(local_extensions)
+extended_env = Environment(
+    extensions=[local_extensions.people_contact_info_Extension]
+)
+
+
+@pytest.mark.parametrize(
+    "author_names, author_emails, expected_output",
+    [
+        # single author
+        (
+            "Alice",
+            "alice@email.com",
+            """[
+  {name='Alice', email='alice@email.com'},
+]""",
+        ),
+        # multiple authors
+        (
+            "Alice, Bob, Charlie",
+            "alice@email.com, bob@email.com, charlie@email.com",
+            """[
+  {name='Alice', email='alice@email.com'},
+  {name='Bob', email='bob@email.com'},
+  {name='Charlie', email='charlie@email.com'},
+]""",
+        ),
+    ],
+)
+def test_expand_to_dict_with_name(
+    author_names, author_emails, expected_output
+):
+
+    template = extended_env.from_string(
+        "{{ author_names | expand_to_dict_with_email(author_emails) }}"
+    )
+    actual_output = template.render(
+        author_names=author_names, author_emails=author_emails
+    )
+    assert actual_output == expected_output
+
+
+def test_expand_to_dict_with_name_bad():
+    template = extended_env.from_string(
+        "{{ author_names | expand_to_dict_with_email(author_emails) }}"
+    )
+    with pytest.raises(KeyError) as excinfo:
+        template.render(
+            author_names="Alice, Bob", author_emails="alice@email.com"
+        )
+    assert str(excinfo.value.args[0]) == (
+        "The number of names and emails must be the same. "
+        "Got 2 names and 1 emails."
+    )
+
+
+@pytest.mark.parametrize(
+    "author_names, author_emails, expected_output",
+    [
+        # single author
+        ("Alice", "alice@email.com", "Alice(alice@email.com)"),
+        # multiple authors
+        (
+            "Alice, Bob, Charlie",
+            ("alice@email.com, bob@email.com, " "charlie@email.com"),
+            (
+                "Alice(alice@email.com), Bob(bob@email.com), "
+                "and Charlie(charlie@email.com)"
+            ),
+        ),
+    ],
+)
+def test_expand_to_str_with_email(
+    author_names, author_emails, expected_output
+):
+    template = extended_env.from_string(
+        "{{ author_names | expand_to_str_with_email(author_emails) }}"
+    )
+    actual_output = template.render(
+        author_names=author_names, author_emails=author_emails
+    )
+    assert actual_output == expected_output
+
+
+@pytest.mark.parametrize(
+    "author_names, expected_output",
+    [
+        # single author
+        ("Alice", "Alice"),
+        # multiple authors
+        ("Alice, Bob, Charlie", "Alice, Bob, and Charlie"),
+    ],
+)
+def test_list_in_str(author_names, expected_output):
+    template = extended_env.from_string("{{ author_names | list_in_str }}")
+    actual_output = template.render(author_names=author_names)
+    assert actual_output == expected_output

--- a/{{ cookiecutter.github_repo_name }}/CODE-OF-CONDUCT.rst
+++ b/{{ cookiecutter.github_repo_name }}/CODE-OF-CONDUCT.rst
@@ -67,7 +67,7 @@ Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-{{ cookiecutter.maintainer_email }}. All complaints will be reviewed and investigated promptly and fairly.
+{{ cookiecutter.maintainer_emails | list_in_str }}. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/{{ cookiecutter.github_repo_name }}/README.rst
+++ b/{{ cookiecutter.github_repo_name }}/README.rst
@@ -129,7 +129,7 @@ Before contributing, please read our `Code of Conduct <https://github.com/{{ coo
 Contact
 -------
 
-For more information on {{ cookiecutter.conda_pypi_package_dist_name }} please visit the project `web-page <https://{{ cookiecutter.github_username_or_orgname }}.github.io/>`_ or email {{ cookiecutter.maintainer_name }} at {{ cookiecutter.maintainer_email }}.
+For more information on {{ cookiecutter.conda_pypi_package_dist_name }} please visit the project `web-page <https://{{ cookiecutter.github_username_or_orgname }}.github.io/>`_ or email the maintainers ``{{ cookiecutter.maintainer_names | expand_to_str_with_email(cookiecutter.maintainer_emails)}}``.
 
 Acknowledgements
 ----------------

--- a/{{ cookiecutter.github_repo_name }}/cookiecutter.json
+++ b/{{ cookiecutter.github_repo_name }}/cookiecutter.json
@@ -1,7 +1,9 @@
 {
-  "maintainer_name": "{{ cookiecutter.maintainer_name }}",
-  "maintainer_email": "{{ cookiecutter.maintainer_email }}",
-  "maintainer_github_username": "{{ cookiecutter.maintainer_github_username }}",
+  "author_names": "{{ cookiecutter.author_names }}",
+  "author_emails": "{{ cookiecutter.author_emails }}",
+  "maintainer_names": "{{ cookiecutter.maintainer_names }}",
+  "maintainer_emails": "{{ cookiecutter.maintainer_emails }}",
+  "maintainer_github_usernames": "{{ cookiecutter.maintainer_github_usernames }}",
   "contributors": "{{ cookiecutter.contributors }}",
   "license_holders": "{{ cookiecutter.license_holders }}",
   "project_name": "{{ cookiecutter.project_name }}",

--- a/{{ cookiecutter.github_repo_name }}/docs/source/index.rst
+++ b/{{ cookiecutter.github_repo_name }}/docs/source/index.rst
@@ -21,7 +21,7 @@ To get started, please visit the :ref:`Getting started <getting-started>` page.
 Authors
 =======
 
-``{{ cookiecutter.project_name }}`` is developed by {{ cookiecutter.contributors }}. The maintainer for this project is {{ cookiecutter.maintainer_name }}. For a detailed list of contributors see
+``{{ cookiecutter.project_name }}`` is developed by {{ cookiecutter.contributors }}. This project is maintained by {{ cookiecutter.maintainer_names | list_in_str }}. For a detailed list of contributors see
 https://github.com/{{ cookiecutter.github_username_or_orgname }}/{{ cookiecutter.github_repo_name }}/graphs/contributors.
 
 ============

--- a/{{ cookiecutter.github_repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.github_repo_name }}/pyproject.toml
@@ -5,12 +5,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "{{ cookiecutter.conda_pypi_package_dist_name }}"
 dynamic=['version', 'dependencies']
-authors = [
-  { name="{{ cookiecutter.maintainer_name }}", email="{{ cookiecutter.maintainer_email }}" },
-]
-maintainers = [
-  { name="{{ cookiecutter.maintainer_name }}", email="{{ cookiecutter.maintainer_email }}" },
-]
+authors = {{ cookiecutter.author_names | expand_to_dict_with_email(cookiecutter.author_emails) }}
+maintainers = {{ cookiecutter.maintainer_names | expand_to_dict_with_email(cookiecutter.maintainer_emails) }}
 description = "{{ cookiecutter.project_short_description }}"
 {%- set keywords_list = (cookiecutter.project_keywords.split(',') if cookiecutter.project_keywords.strip() else []) -%}
 {%- set ns = namespace(keywords_trim = []) -%}


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->

Closes #536 

### What should the reviewer(s) do?

Input:
<img width="1030" height="579" alt="image" src="https://github.com/user-attachments/assets/a135bb6a-4140-4960-b056-77fe7d2068f7" />

Output:
```
# pyprojec.toml
authors = [
  {name='Alice', email='alice@email.com'},
]
maintainers = [
  {name='Alice', email='alice@email.com'},
  {name='Bob', email='bob@email.com'},
  {name='Charlie', email='charlie@email.com'},
]

# index.rst
This project is maintained by Alice, Bob, and Charlie. For a detailed list of contributors see ...

# CODE-OF-CONDUCT
...  responsible for enforcement at alice@email.com, bob@email.com, and charlie@email.com. 

# README
... or email the maintainers ``Alice(alice@email.com), Bob(bob@email.com), and Charlie(charlie@email.com)``.
```


<!-- Merge the code, provide feedback, initiate a discussion, etc. -->

<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->
