### PR TITLE
doc: add descriptions for multiple authors and multiple maintainers

### DIFF
--- a/docs/source/snippets/user-input-level-5.rst
+++ b/docs/source/snippets/user-input-level-5.rst
@@ -4,15 +4,21 @@
 
       * - Prompt
         - Description and example
-      * - maintainer_name
-        - The name of the project maintainer. This person will make the public releases.
+      * - author_names
+        - The name(s) of the project author(s). Names should be separated by commas.
+          e.g. Simon Billinge, Sanjoon Bob Lee
+      * - author_emails
+        - The author(s)' email address. Email addresses should be separated by commas.
+          e.g. sb2896@columbia.edu, sl5400@columbia.edu
+      * - maintainer_names
+        - The name(s) of the project maintainer(s). These persons will make the public releases.
           e.g., Simon Billinge
-      * - maintainer_email
-        - The maintainer's email address.
+      * - maintainer_emails
+        - The maintainer(s)' email address.
           e.g., sbillinge@columbia.edu
-      * - maintainer_github_username
-        - The maintainer's GitHub username.
-          e.g., sbillinge
+      * - maintainer_github_usernames
+        - The maintainer(s)' GitHub username. Usernames should be separated by commas.
+          e.g., sbillinge, bobleesj
       * - contributors
         - Individuals or groups contributing to the project.
           e.g., Sangjoon Lee, Simon Billinge, Billinge Group members

--- a/docs/source/snippets/user-input-level-5.rst
+++ b/docs/source/snippets/user-input-level-5.rst
@@ -5,20 +5,20 @@
       * - Prompt
         - Description and example
       * - author_names
-        - The name(s) of the project author(s). Names should be separated by commas.
-          e.g. Simon Billinge, Sanjoon Bob Lee
+        - The name(s) of the project author(s). Please separate names by commas.
+          e.g. Simon Billinge, Sangjoon Bob Lee
       * - author_emails
-        - The author(s)' email address. Email addresses should be separated by commas.
-          e.g. sb2896@columbia.edu, sl5400@columbia.edu
+        - The author(s)' email address. Please separated emails by commas. The number and order of emails should match author_names.
+          e.g. sbillinge@columbia.edu, bob@columbia.edu
       * - maintainer_names
-        - The name(s) of the project maintainer(s). These persons will make the public releases.
-          e.g., Simon Billinge
+        - The name(s) of the project maintainer(s). These persons will make the public releases. Please separate with commas.
+          e.g., Simon Billinge, Yuchen Xiao
       * - maintainer_emails
-        - The maintainer(s)' email address.
-          e.g., sbillinge@columbia.edu
+        - The maintainer(s)' email address. Please separate with commas. The number and order of emails should match maintainer_names.
+          e.g., sbillinge@columbia.edu, yxiao@columbia.edu
       * - maintainer_github_usernames
-        - The maintainer(s)' GitHub username.
-          e.g., sbillinge
+        - The maintainer(s)' GitHub username. Please separate with commas. The number and order of emails should match maintainer_names.
+          e.g., simon-gh, yuchen-gh
       * - contributors
         - Individuals or groups contributing to the project.
           e.g., Sangjoon Lee, Simon Billinge, Billinge Group members

--- a/docs/source/snippets/user-input-level-5.rst
+++ b/docs/source/snippets/user-input-level-5.rst
@@ -17,8 +17,8 @@
         - The maintainer(s)' email address.
           e.g., sbillinge@columbia.edu
       * - maintainer_github_usernames
-        - The maintainer(s)' GitHub username. Usernames should be separated by commas.
-          e.g., sbillinge, bobleesj
+        - The maintainer(s)' GitHub username.
+          e.g., sbillinge
       * - contributors
         - Individuals or groups contributing to the project.
           e.g., Sangjoon Lee, Simon Billinge, Billinge Group members

--- a/news/doc-multiple-authors.rst
+++ b/news/doc-multiple-authors.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Add descriptions for multiple authors and multiple maintainers.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->
Closes #616

Add description for multiple authors and multiple maintainers in `user-input-level-5.rst`

### What should the reviewer(s) do?

Please see the modified rendered documentation.

<img width="755" height="231" alt="image" src="https://github.com/user-attachments/assets/3f9a9ba5-52c4-4536-8fd6-2f31e35435a8" />

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->

<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->
