### PR TITLE
chore: add additional example files to be removed when running `package update`

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -41,6 +41,8 @@ def update_package():
         ),
         "docs/source/getting-started.rst",
         "tests/test_functions.py",
+        "docs/source/img/scikit-package-logo-text.png",
+        "docs/source/snippets/example-table.rst",
     ]
     example_files_in_src = [
         "src/{{ cookiecutter.package_dir_name }}/functions.py",

--- a/news/rm-example-files.rst
+++ b/news/rm-example-files.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Add additional example files to be removed when running ``package update``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->
Closes #619

### What should the reviewer(s) do?

`scikit-package-logo-text.png` and `example-table.rst` will also be removed when running `package update`.

Please see if it is the expected behavior.

Input:
Doesn't change.

Output:
Here is an example output run in a project `agents_for_diffpy`. This project didn't have `scikit-package-logo-text.png` and `example-table.rst` previously, and also won't have them after `package update` as shown below.
```
├── docs
│   ├── make.bat
│   ├── Makefile
│   └── source
│       ├── api
│       │   └── agents_for_diffpy.rst
│       ├── conf.py
│       ├── img
│       ├── index.rst
│       ├── license.rst
│       ├── release.rst
│       ├── snippets
│       └── _static
```
