### PR TITLE
chore: fix grammar in help message for `package broadcast`

### DIFF
--- a/news/fix-typo.rst
+++ b/news/fix-typo.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* <news item>
+* No news added: Fix typo in the help message for ``package broadcast``.
 
 **Deprecated:**
 

--- a/src/scikit_package/scikit_package_app.py
+++ b/src/scikit_package/scikit_package_app.py
@@ -139,7 +139,8 @@ def setup_subparsers(parser):
     parser_news.set_defaults(func=add.news_item, subcommand="news")
 
     parser_broadcast = parser.add_parser(
-        "broadcast", help="Broadcast a issue to many GitHub repositories."
+        "broadcast",
+        help="Broadcast an issue to a list of GitHub repositories.",
     )
     _add_broadcast_args(parser_broadcast)
     parser_broadcast.set_defaults(func=broadcast_issue_to_repos)


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->
Closes #648

### What should the reviewer(s) do?

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->

<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->

The modified help message is now "Broadcast an issue to a list of GitHub repositories."
