### PR TITLE
fix: fall back to template default for unknown keys in post_gen workflow hook

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -233,7 +233,8 @@ def update_workflow():
 
         def replace_match(match):
             key = match.group(1)
-            return str(workflow_input[key])
+            default = match.group(2)
+            return str(workflow_input.get(key, default))
 
         pattern = re.compile(r"\{\{\s*(\w+)\s*/\s*([^\s\}]+)\s*\}\}")
         return pattern.sub(replace_match, content)

--- a/news/fix-post-gen-hook-unknown-key.rst
+++ b/news/fix-post-gen-hook-unknown-key.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* fix post_gen hook: fall back to template default for unknown workflow_input keys
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
## Problem

`replace_match` in `post_gen_project.py` uses `workflow_input[key]`, which raises `KeyError` for any template variable not in the pre-defined `workflow_input` dict. This silently kills the entire workflow-generation loop. Any template alphabetically later than the failing one is never written.

**Concrete impact:** when `release-scripts` PR #266 added `{{ BRANCH/main }}` to `check-news-item.yml`, `package create` started producing only `build-and-publish-docs-on-dispatch.yml` and `build-wheel-release-upload.yml` — the two templates alphabetically before `check-news-item.yml`. `matrix-and-codecov.yml` and `tests-on-pr.yml` were silently dropped.

(`release-scripts` PR #269 reverts `{{ BRANCH/main }}` to a hardcoded `main` to fix the immediate regression, but the underlying fragility remains.)

## Fix

Use `workflow_input.get(key, default)` so unknown keys resolve to the template's declared default value instead of crashing. This matches the behaviour of `update_workflow.py`, which also falls back to the default for keys not supplied by the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)