### PR TITLE
build: replace docformatter with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,11 +62,10 @@ repos:
         additional_dependencies:
           - "prettier@^3.2.4"
         types: [yaml, markdown, json]
-  # docformatter - PEP 257 compliant docstring formatter
-  - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.7
+  # ruff - An extremely fast Python linter and code formatter, written in Rust.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
     hooks:
-      - id: docformatter
-        language_version: python3.13
-        additional_dependencies: [tomli]
-        args: [--in-place, --config, ./pyproject.toml]
+      - id: ruff-check
+        args: [--fix, --config=pyproject.toml]
+        exclude: ^\{\{\s*cookiecutter\.github_repo_name\s*\}\}/

--- a/news/ruff.rst
+++ b/news/ruff.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Changed `pre-commit` workflow from docformatter to ruff
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,10 +65,12 @@ exclude-file = ".codespell/ignore_lines.txt"
 ignore-words = ".codespell/ignore_words.txt"
 skip = "*.cif,*.dat"
 
-[tool.docformatter]
-recursive = true
-wrap-summaries = 72
-wrap-descriptions = 72
+[tool.ruff]
+line-length = 115
+exclude = ["hooks/post_gen_project.py"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
 
 [tool.black]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ ignore-words = ".codespell/ignore_words.txt"
 skip = "*.cif,*.dat"
 
 [tool.ruff]
-line-length = 115
+line-length = 79
 exclude = ["hooks/post_gen_project.py"]
 
 [tool.ruff.lint.pydocstyle]

--- a/{{ cookiecutter.github_repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.github_repo_name }}/.pre-commit-config.yaml
@@ -57,10 +57,9 @@ repos:
       - id: prettier
         additional_dependencies:
           - "prettier@^3.2.4"
-  # docformatter - PEP 257 compliant docstring formatter
-  - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.7
+  # ruff - An extremely fast Python linter and code formatter, written in Rust.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
     hooks:
-      - id: docformatter
-        additional_dependencies: [tomli]
-        args: [--in-place, --config, ./pyproject.toml]
+      - id: ruff-check
+        args: [--fix]

--- a/{{ cookiecutter.github_repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.github_repo_name }}/pyproject.toml
@@ -63,7 +63,7 @@ ignore-words = ".codespell/ignore_words.txt"
 skip = "*.cif,*.dat"
 
 [tool.ruff]
-line-length = 115
+line-length = 79
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/{{ cookiecutter.github_repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.github_repo_name }}/pyproject.toml
@@ -62,10 +62,11 @@ exclude-file = ".codespell/ignore_lines.txt"
 ignore-words = ".codespell/ignore_words.txt"
 skip = "*.cif,*.dat"
 
-[tool.docformatter]
-recursive = true
-wrap-summaries = 72
-wrap-descriptions = 72
+[tool.ruff]
+line-length = 115
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
@sbillinge ready to review, I replaced the docformatter with ruff. Note that ruff would accidentally change the formatting of some cookiecuttered variable, which is undesireable, so I add exclusion to auto-lint with the cookiecutter of the build of package. But for the package produced by the scikit-package, we don't need to set the exclusion. 