### PR TITLE
build: fix dependency need in the running workflow of get-python-version

### DIFF
--- a/.github/workflows/build-and-publish-docs-on-dispatch.yml
+++ b/.github/workflows/build-and-publish-docs-on-dispatch.yml
@@ -10,6 +10,7 @@ jobs:
       python_version: 0
 
   docs:
+    needs: get-python-version
     uses: scikit-package/release-scripts/.github/workflows/_release-docs.yml@v0
     with:
       project: scikit-package

--- a/news/fix-single-workflow.rst
+++ b/news/fix-single-workflow.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed running single `docs-on-dispatch` workflow on Github Action
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
@sbillinge ready to review, this problem is seen in the Github Action https://github.com/diffpy/diffpy.fourigui/actions/runs/24108556336, where we failed to make the docs release. 
the reason is that we failed to make the `get-python-version` needs into the docs build, so it failed to fetch the version with `FromJSON` method. So, we could add this and test if this could fix the problem. Closes #691 