### PR TITLE
feat: make Codecov optional at package create (default off)

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -17,6 +17,7 @@
   "maximum_supported_python_version": "3.14",
   "project_needs_c_code_compiled": ["No", "Yes"],
   "project_has_gui_tests": ["No", "Yes"],
+  "use_codecov": ["No", "Yes"],
   "_is_skpkg_update": "No",
   "_copy_without_render": ["*.html", "*.js", ".github/*"],
   "_extensions": ["hooks.local_extensions.people_contact_info_Extension"]

--- a/docs/source/support/frequently-asked-questions.rst
+++ b/docs/source/support/frequently-asked-questions.rst
@@ -519,7 +519,7 @@ In Level 5, what are the workflows running in each pull request?
 
 #. The second workflow uses ``pre-commit CI``. This workflow checks the incoming code in the PR using ``pre-commit`` hooks and automatically applies fixes when possible. If any fixes are made, an additional commit is created by the ``pre-commit`` app. However, some hooks, such as spell checkers, may still fail even after auto-fixes. In such cases, the CI fails. The user first needs to pull the additional commit made by the ``pre-commit CI``, fix the error manually, and then push a commit to the working branch.
 
-#. The third workflow uses the ``Codecov`` app, which adds a comment to the PR summarizing the changes in code coverage as part of the ``.github/workflows/tests-on-pr.yml`` workflow. This workflow fails if no tests are provided for the new code or if the test coverage percentage decreases below the acceptable threshold. The threshold can be adjusted in the ``.codecov.yml`` file located in the project root directory. If you have a private repository and Codecov cannot be run, refer to :ref:`faq-private-repo-no-codecov`.
+#. Optionally, if you chose ``use_codecov: Yes`` at package create time, the PR test workflow can upload coverage to the ``Codecov`` app, which may comment on the PR with coverage changes. That path fails if coverage drops below the threshold in ``.codecov.yml``. Codecov is **off by default**; see :ref:`faq-private-repo-no-codecov`.
 
 #. The fourth workflow checks for a news file in the PR using ``.github/workflows/check-news-item.yml``. If no news item is included for the proposed changes, this workflow fails and leaves a comment prompting the contributor to submit a new PR with the appropriate news file. Please refer to the best practices section on :ref:`news items <news-item-practice>`.
 
@@ -597,12 +597,40 @@ After this step, the reusable workflow then runs the ``pytest`` command. To see 
 
 .. _faq-private-repo-no-codecov:
 
-I have a private repo and don't have a Codecov paid plan.  Can I modify the CI workflows for this situation?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+How do I turn Codecov on or off for a package?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, the workflows in ``tests-on-pr.yml`` and ``matrix-and-codecov-on-merge-to-main.yml`` will have a section that uploads the code coverage to Codecov, and CI will fail if unsuccessful. Codecov is available for free on public repositories but requires a paid plan to run on private repositories. In the latter case, if you would like to turn off Codecov, we offer an alternative CI workflow that runs the tests without it.
+When you run ``package create`` (or the Level 5 cookiecutter), the
+``use_codecov`` prompt controls whether CI uploads coverage to Codecov.
 
-In addition to being able to customize additional commands to be run in the ``run:`` section (see :ref:`faq-github-actions-extra-cli-commands` above), you can also change the workflows that you want your repository to run. By default, ``scikit-package`` will run the ``tests-on-pr.yml`` and ``matrix-and-codecov-on-merge-to-main.yml`` workflows in the ``scikit-package/release-scripts`` repository. It is possible to override this default and run a different workflow for your CI if it is available in ``scikit-package/release-scripts``. For example, for the situation above we offer we offer ``tests-on-pr-no-codecov.yml`` and ``matrix-no-codecov-on-merge-to-main.yml`` which run the tests without Codecov.
+- **No (default):** PR and matrix workflows call the
+  ``_tests-on-pr-no-codecov.yml`` and
+  ``_matrix-no-codecov-on-merge-to-main.yml`` reusable workflows. No
+  ``CODECOV_TOKEN`` secret is required, and ``.codecov.yml`` is not kept
+  in the new project.
+- **Yes:** CI uses the Codecov upload path
+  (``_tests-on-pr.yml`` / ``_matrix-and-codecov-on-merge-to-main.yml``)
+  and expects a ``CODECOV_TOKEN`` repository or org secret. See
+  :ref:`codecov-token-setup` for how to obtain the token.
+
+If you already generated a package with Codecov enabled and want to
+disable it (for example on a private repo without a Codecov paid plan,
+or simply because you prefer not to use Codecov), switch the reusable
+workflows manually as follows.
+
+When Codecov is enabled, the workflows in ``tests-on-pr.yml`` and
+``matrix-and-codecov.yml`` upload coverage, and CI fails if that upload
+is unsuccessful. Codecov is free on public repositories but needs a paid
+plan on private repositories.
+
+You can also change the workflows that your repository runs. When
+``use_codecov`` is No (the default for new packages), ``scikit-package``
+points at the no-Codecov reusable workflows in
+``scikit-package/release-scripts``. When Codecov is enabled, it uses
+``_tests-on-pr.yml`` and ``_matrix-and-codecov-on-merge-to-main.yml``.
+To switch an existing repo off Codecov, use
+``_tests-on-pr-no-codecov.yml`` and
+``_matrix-no-codecov-on-merge-to-main.yml`` as shown below.
 
 To do so, you can modify the script that your workflow files are calling in the ``uses:`` section. Normally, you'd be calling the following in ``tests-on-pr.yml`` and ``matrix-and-codecov-on-merge-to-main.yml``, respectively.
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -264,6 +264,54 @@ def update_workflow():
         print(f"Error: {str(e)}")
 
 
+def configure_codecov():
+    """Enable or disable Codecov based on the use_codecov cookiecutter prompt.
+
+    Default is No: point PR/matrix CI at the no-codecov release-scripts
+    workflows, drop CODECOV_TOKEN secrets, and remove .codecov.yml plus
+    the optional codecov test dependency. Choose Yes at create time to
+    keep the Codecov upload path (and CODECOV_TOKEN secret requirement).
+    """
+    use_codecov = "{{ cookiecutter.use_codecov }}" == "Yes"
+    if use_codecov:
+        return
+
+    workflows_dir = ROOT / ".github" / "workflows"
+    replacements = {
+        "tests-on-pr.yml": (
+            "workflows/_tests-on-pr.yml@",
+            "workflows/_tests-on-pr-no-codecov.yml@",
+        ),
+        "matrix-and-codecov.yml": (
+            "workflows/_matrix-and-codecov-on-merge-to-main.yml@",
+            "workflows/_matrix-no-codecov-on-merge-to-main.yml@",
+        ),
+    }
+    secrets_block = re.compile(
+        r"\n    secrets:\n      CODECOV_TOKEN: \$\{\{ secrets\.CODECOV_TOKEN \}\}\n"
+    )
+
+    for filename, (old, new) in replacements.items():
+        path = workflows_dir / filename
+        if not path.exists():
+            continue
+        content = path.read_text(encoding="utf-8")
+        content = content.replace(old, new)
+        content = secrets_block.sub("\n", content)
+        path.write_text(content, encoding="utf-8")
+
+    codecov_yml = ROOT / ".codecov.yml"
+    if codecov_yml.exists():
+        codecov_yml.unlink()
+
+    tests_req = ROOT / "requirements" / "tests.txt"
+    if tests_req.exists():
+        lines = tests_req.read_text(encoding="utf-8").splitlines()
+        kept = [line for line in lines if line.strip() != "codecov"]
+        if kept != lines:
+            tests_req.write_text("\n".join(kept) + ("\n" if kept else ""), encoding="utf-8")
+
+
 def main():
     """Execute when user runs cookiecutter."""
     if "." in "{{ cookiecutter.project_name }}":
@@ -271,6 +319,7 @@ def main():
     if "{{ cookiecutter.project_needs_c_code_compiled }}" == "Yes":
         wrapper_setup()
     update_workflow()
+    configure_codecov()
     print(
         f"""
     Congratulations! A new Python project is created!

--- a/news/no-codecov-default.rst
+++ b/news/no-codecov-default.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* Add a ``use_codecov`` cookiecutter prompt (default ``No``) so Codecov is optional at package create time.
+
+**Changed:**
+
+* Default new Level 5 packages to the no-Codecov CI workflows
+  (``_tests-on-pr-no-codecov.yml`` and ``_matrix-no-codecov-on-merge-to-main.yml``),
+  omit the ``CODECOV_TOKEN`` secret, and skip shipping ``.codecov.yml`` unless
+  the user chooses ``use_codecov: Yes``.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address?

closes #714

Codecov is wired into Level 5 CI by default. Upload failures (token, branch protection, private repos) make green pytest red. Many packages do not want Codecov.

### What should the reviewer(s) do?

Merge.

- New cookiecutter prompt ``use_codecov``: **No** (default) or **Yes**
- **No:** CI uses ``_tests-on-pr-no-codecov.yml`` and ``_matrix-no-codecov-on-merge-to-main.yml``, no ``CODECOV_TOKEN``, no ``.codecov.yml``, drop ``codecov`` from ``tests.txt``
- **Yes:** keep current Codecov path
- FAQ updated for the prompt and for switching existing repos

release-scripts already provides the no-Codecov workflows; this is create-time customization only.