### PR TITLE
fix:Fixed CLI entry point generated with correct module path in `project.script`

### DIFF
--- a/news/fix-cli-entry.rst
+++ b/news/fix-cli-entry.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed CLI entry point generated with correct module path in `project.scripts`
+
+**Security:**
+
+* <news item>

--- a/{{ cookiecutter.github_repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.github_repo_name }}/pyproject.toml
@@ -52,7 +52,7 @@ exclude = []  # exclude packages matching these glob patterns (empty by default)
 namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 
 [project.scripts]
-{{ cookiecutter.conda_pypi_package_dist_name|replace('.', '-') }} = "{{ cookiecutter.project_name|replace(' ', '_')|replace('-', '_')|lower }}.app:main"
+{{ cookiecutter.conda_pypi_package_dist_name|replace('.', '-') }} = "{{ cookiecutter.package_dir_name }}.{{ cookiecutter.package_dir_name.split('.')[-1] }}_app:main"
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements/pip.txt"]}


### PR DESCRIPTION
@sbillinge ready to review. Closes #716 
In this PR, we fixed the script fetching logic that it should start from `src/<dir_name>.<package_name>_app` to make it work properly. I have tested on `diffpy.structure` and it finds the files and running the command properly.